### PR TITLE
Set up development environment (AGENTS.md + Cursor Cloud instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# calldiff
+
+`calldiff` is a TypeScript CLI that diffs call stacks across git commits (AST-based, powered by oxc-parser). See `README.md` for usage and `## Dev` for the dev command.
+
+## Cursor Cloud specific instructions
+
+- This is a single Node.js CLI package (npm, `package-lock.json`). Node `>=20` is required; the VM's default Node satisfies this.
+- Standard commands live in `package.json` `scripts`:
+  - Typecheck/build: `npm run build` (runs `tsc`, emits `dist/`). There is no separate lint tool — `tsc` under `strict` is the closest thing to a lint check.
+  - Tests: `npm test` (`tsx --test test/**/*.test.ts`).
+  - Run in dev: `npm run dev -- <args>` (runs `src/cli.ts` via `tsx`); run built binary: `node dist/cli.js <args>`.
+- The tool operates on a git repository, so run it from inside one. A convenient smoke test is to diff this repo's own two commits, e.g. `npm run dev -- f007467 99a6c6d`, which prints an ASCII callstack diff.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `calldiff` CLI and documents it for future Cursor Cloud agents.

- Verified dependency install (`npm ci`), typecheck/build (`npm run build`), tests (`npm test`), and end-to-end CLI runs.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the standard commands and a smoke-test invocation.

## Environment

- Single Node.js CLI package (npm, `package-lock.json`), Node `>=20` (VM has v22).
- No separate lint tool; `tsc` (strict) via `npm run build` is the closest check.

## Verification

| Step | Command | Result |
|---|---|---|
| Install | `npm ci` | 11 packages, 0 vulnerabilities |
| Build / typecheck | `npm run build` | passes (`tsc`, emits `dist/`) |
| Tests | `npm test` | 5 passed, 0 failed |
| Run (dev) | `npm run dev -- f007467 99a6c6d` | prints ASCII callstack diff |
| Run (built) | `node dist/cli.js --help` / diff | works |

Update script (runs on VM startup): `npm ci`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a31ab8ee-23a0-43d0-804c-58bec91dda0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a31ab8ee-23a0-43d0-804c-58bec91dda0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

