### PR TITLE
Reframe docs around multi-language support (not TypeScript-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # calldiff
 
-`calldiff` is a CLI that diffs call stacks across git commits for 22 languages (AST-based, powered by tree-sitter). See `README.md` for usage and `## Dev` for the dev command.
+`calldiff` is a CLI for agentic code review: it diffs call stacks across git commits for 22 languages (AST-based, powered by tree-sitter). See `README.md` for usage and `## Dev` for the dev command.
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # calldiff
 
-`calldiff` is a TypeScript CLI that diffs call stacks across git commits (AST-based, powered by tree-sitter). See `README.md` for usage and `## Dev` for the dev command.
+`calldiff` is a CLI that diffs call stacks across git commits for 22 languages (AST-based, powered by tree-sitter). See `README.md` for usage and `## Dev` for the dev command.
 
 ## Cursor Cloud specific instructions
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tanishq Kancharla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # calldiff
 
-Diff TypeScript call stacks across git commits — like `git diff`, but for who-calls-whom.
+Diff call stacks across git commits — like `git diff`, but for who-calls-whom.
+
+Works across **22 languages** (TypeScript, TSX, JavaScript, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml).
 
 ```
   PiService.createAgentSession(options)
@@ -68,10 +70,6 @@ If you omit `--entry`, calldiff infers exported functions whose expanded call tr
 2. Detects language by file extension, loads a [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar (bundled or on-demand into `~/.cache/calldiff/grammars`), and parses
 3. Builds per-function callee lists and expands them into call trees
 4. Diffs the trees and prints an ASCII callstack diff
-
-### Supported languages
-
-TypeScript/TSX, JavaScript, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml.
 
 Grammars install on first use (override cache with `CALLDIFF_GRAMMAR_CACHE`). This is syntactic (AST-based), not a full typechecker — dynamic calls won’t resolve.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Diff call stacks across git commits — like `git diff`, but for who-calls-whom.
 
-Works across **22 languages** (TypeScript, TSX, JavaScript, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml).
+Built for **agentic code review**: when an agent (or you) rewires call flow, plain line diffs bury the shape of the change. `calldiff` shows which callees appeared, disappeared, or moved under an entrypoint — across **22 languages**.
 
-```
+```diff
   PiService.createAgentSession(options)
 - ├─ AuthStorage.create()
 - ├─ new ModelRegistry
@@ -15,10 +15,16 @@ Works across **22 languages** (TypeScript, TSX, JavaScript, Python, Go, Rust, Ja
 + │  └─ new ModelRegistry
 ```
 
+## Prompt for agents
+
+Paste this when you want a walkthrough of call-flow changes:
+
+> dearest clod, walk me through the code changes you made using `npx calldiff@latest`
+
 ## Install
 
 ```bash
-npx calldiff
+npx calldiff@latest
 # or
 npm install -g calldiff
 ```
@@ -63,6 +69,10 @@ calldiff main feature -- src/lib
 - `if (cond)` / `else` / `else if (cond)` — conditional arms (no continuing `│` rail)
 
 If you omit `--entry`, calldiff infers exported functions whose expanded call trees changed (and may show several).
+
+### Supported languages
+
+TypeScript, TSX, JavaScript, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calldiff",
   "version": "0.1.0",
-  "description": "Diff call stacks across git commits (22 languages)",
+  "description": "Diff call stacks across git commits for agentic code review (22 languages)",
   "type": "module",
   "bin": {
     "calldiff": "./dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calldiff",
   "version": "0.1.0",
-  "description": "Diff TypeScript call stacks across git commits",
+  "description": "Diff call stacks across git commits (22 languages)",
   "type": "module",
   "bin": {
     "calldiff": "./dist/cli.js"
@@ -30,10 +30,14 @@
   "keywords": [
     "callgraph",
     "diff",
-    "typescript",
+    "callstack",
     "tree-sitter",
     "git",
-    "callstack"
+    "multi-language",
+    "typescript",
+    "python",
+    "rust",
+    "go"
   ],
   "author": "Tanishq Kancharla",
   "license": "MIT",

--- a/src/args.ts
+++ b/src/args.ts
@@ -105,7 +105,7 @@ export function parseArgs(argv: string[], cwd = process.cwd()): CliOptions {
 }
 
 export function printHelp(): void {
-  console.log(`calldiff — diff call stacks across git commits (22 languages)
+  console.log(`calldiff — diff call stacks across git commits for agentic review (22 languages)
 
 Usage:
   calldiff

--- a/src/args.ts
+++ b/src/args.ts
@@ -105,7 +105,7 @@ export function parseArgs(argv: string[], cwd = process.cwd()): CliOptions {
 }
 
 export function printHelp(): void {
-  console.log(`calldiff — diff TypeScript call stacks across git commits
+  console.log(`calldiff — diff call stacks across git commits (22 languages)
 
 Usage:
   calldiff
@@ -131,5 +131,9 @@ Labels:
   functionName
   ClassName.method
   new ClassName
+
+Languages:
+  TypeScript, TSX, JavaScript, Python, Go, Rust, Java, Ruby, C, C++, C#,
+  PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml
 `);
 }

--- a/test/expectCallstack.ts
+++ b/test/expectCallstack.ts
@@ -11,7 +11,7 @@ type CallstackAssertion = {
 
 /**
  * Vitest fixtures for the callstack-diff test format:
- * a +/- TypeScript file diff in, ASCII callstack diff out.
+ * a +/- source file diff in, ASCII callstack diff out.
  */
 export const test = base.extend<{
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Calldiff supports 22 languages and is aimed at agentic code review, but the README and public copy still led with “TypeScript.” This PR reframes that surface area, adds an MIT `LICENSE`, and gives agents a pasteable prompt.

## Changes

- **README**: agentic-review positioning, sample output as a `diff` fence, agent prompt (`npx calldiff@latest`), 22-language list
- **package.json** / **CLI help**: description aligned with agentic review + multi-language
- **LICENSE**: standard MIT text (copyright 2026 Tanishq Kancharla)
- **AGENTS.md**: matching blurb

## Follow-up (needs repo admin)

GitHub About can’t be edited with this token (`gh repo edit` → 403). Suggested:

> Diff call stacks across git commits for agentic code review (22 languages)

Topics: `callgraph`, `diff`, `callstack`, `tree-sitter`, `git`, `multi-language`

## Test plan

- [x] `npm run build`
- [x] `npm run dev -- --help` shows updated blurb
- Docs/license-only; no behavior change expected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe6a2-21d9-736c-9b28-c94421950b6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe6a2-21d9-736c-9b28-c94421950b6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

