### PR TITLE
Speed up snapshot loading and entrypoint inference

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -2,6 +2,7 @@
  * Multi-language extraction: detect by file extension, load grammar
  * (bundled or on-demand cache), parse, then run the language extractor.
  */
+import { createHash } from "node:crypto";
 import Parser from "tree-sitter";
 import type { CallStep, FunctionInfo } from "./types.js";
 import { loadGrammarPackage, resolveLanguage } from "./languages/grammars.js";
@@ -44,6 +45,30 @@ export function extractFunctions(
     const lines = linesFromOffsets(source, fn.start, fn.end);
     return { ...fn, ...lines };
   });
+}
+
+type CachedFunction = Omit<FunctionInfo, "file">;
+export type ExtractionCache = Map<string, CachedFunction[]>;
+
+export function extractCached(
+  file: string,
+  source: string,
+  cache: ExtractionCache,
+): FunctionInfo[] {
+  const extractor = detectLanguage(file);
+  if (!extractor) return [];
+
+  const digest = createHash("sha256").update(source).digest("hex");
+  const key = `${file}\0${extractor.id}\0${digest}`;
+  let functions = cache.get(key);
+
+  if (!functions) {
+    functions = extractFunctions(file, source).map(
+      ({ file: ignored, ...fn }) => fn,
+    );
+    cache.set(key, functions);
+  }
+  return functions.map((fn) => ({ ...fn, file }));
 }
 
 export type FunctionIndex = Map<string, FunctionInfo>;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,15 +1,25 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative, resolve, sep } from "node:path";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { listSupportedExtensions } from "./languages/registry.js";
 import type { Snapshot } from "./types.js";
 
-function git(cwd: string, args: string[]): string {
+function gitBuffer(
+  cwd: string,
+  args: string[],
+  input?: Buffer,
+  maxBuffer = 64 * 1024 * 1024,
+): Buffer {
   return execFileSync("git", args, {
     cwd,
-    encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
-    stdio: ["ignore", "pipe", "pipe"],
+    input,
+    maxBuffer,
+    stdio: ["pipe", "pipe", "pipe"],
   });
+}
+
+function git(cwd: string, args: string[]): string {
+  return gitBuffer(cwd, args).toString("utf8");
 }
 
 export function assertGitRepo(cwd: string): void {
@@ -143,19 +153,7 @@ export function verifyCommit(cwd: string, ref: string): void {
   }
 }
 
-import { listSupportedExtensions } from "./languages/registry.js";
-
 const SOURCE_EXT = new Set(listSupportedExtensions());
-const SKIP_DIRS = new Set([
-  "node_modules",
-  "dist",
-  "build",
-  "coverage",
-  ".git",
-  ".next",
-  ".turbo",
-  "out",
-]);
 
 function isSourceFile(path: string): boolean {
   const lower = path.toLowerCase();
@@ -165,34 +163,68 @@ function isSourceFile(path: string): boolean {
   return SOURCE_EXT.has(lower.slice(dot));
 }
 
-function walkWorktree(root: string, dir: string, out: string[]): void {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
+export interface SnapshotFile {
+  path: string;
+  /** Git blob metadata. Worktree files do not have it. */
+  oid?: string;
+  size?: number;
+}
 
-  for (const entry of entries) {
-    if (entry.name.startsWith(".") && entry.name !== ".") continue;
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      walkWorktree(root, full, out);
-      continue;
-    }
-    if (entry.isFile() && isSourceFile(entry.name)) {
-      out.push(relative(root, full).split(sep).join("/"));
-    }
+function isRegularFile(path: string): boolean {
+  try {
+    return lstatSync(path).isFile();
+  } catch {
+    return false;
   }
 }
 
-function listCommitSourceFiles(cwd: string, ref: string): string[] {
-  const output = git(cwd, ["ls-tree", "-r", "--name-only", ref]);
+function listWorktreeFiles(cwd: string): SnapshotFile[] {
+  const output = git(cwd, [
+    "ls-files",
+    "-z",
+    "--cached",
+    "--others",
+    "--exclude-standard",
+  ]);
+
   return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line && isSourceFile(line));
+    .split("\0")
+    .filter(
+      (path) =>
+        path && isSourceFile(path) && isRegularFile(resolve(cwd, path)),
+    )
+    .map((path) => ({ path }));
+}
+
+function listCommitFiles(cwd: string, ref: string): SnapshotFile[] {
+  const output = git(cwd, ["ls-tree", "-r", "-z", "-l", ref]);
+  const files: SnapshotFile[] = [];
+
+  for (const record of output.split("\0")) {
+    if (!record) continue;
+
+    const tab = record.indexOf("\t");
+    if (tab < 0) continue;
+
+    const [mode, type, oid, sizeText] = record
+      .slice(0, tab)
+      .trim()
+      .split(/\s+/);
+    const path = record.slice(tab + 1);
+    const regular = mode === "100644" || mode === "100755";
+    const size = Number(sizeText);
+    if (
+      regular &&
+      type === "blob" &&
+      oid &&
+      Number.isInteger(size) &&
+      isSourceFile(path)
+    ) {
+      files.push({ path, oid, size });
+    }
+  }
+
+  return files;
 }
 
 function pathAllowed(file: string, pathFilters: string[]): boolean {
@@ -205,6 +237,21 @@ function pathAllowed(file: string, pathFilters: string[]): boolean {
       file.endsWith(normalized)
     );
   });
+}
+
+export function listSnapshotFiles(
+  cwd: string,
+  snapshot: Snapshot,
+  pathFilters: string[] = [],
+): SnapshotFile[] {
+  const files =
+    snapshot.kind === "worktree"
+      ? listWorktreeFiles(cwd)
+      : listCommitFiles(cwd, snapshot.ref);
+
+  return files
+    .filter((file) => pathAllowed(file.path, pathFilters))
+    .sort((a, b) => a.path.localeCompare(b.path));
 }
 
 /** @deprecated Use listSourceFiles */
@@ -221,34 +268,120 @@ export function listSourceFiles(
   snapshot: Snapshot,
   pathFilters: string[] = [],
 ): string[] {
-  const files =
-    snapshot.kind === "worktree"
-      ? (() => {
-          const out: string[] = [];
-          walkWorktree(cwd, cwd, out);
-          return out;
-        })()
-      : listCommitSourceFiles(cwd, snapshot.ref);
-
-  return files.filter((file) => pathAllowed(file, pathFilters)).sort();
+  return listSnapshotFiles(cwd, snapshot, pathFilters).map((file) => file.path);
 }
 
-export function readSnapshotFile(
-  cwd: string,
-  snapshot: Snapshot,
-  file: string,
-): string | null {
-  if (snapshot.kind === "worktree") {
-    const full = resolve(cwd, file);
-    if (!existsSync(full) || !statSync(full).isFile()) return null;
-    return readFileSync(full, "utf8");
+const BATCH_BYTES = 32 * 1024 * 1024;
+
+type Blob = { oid: string; size: number };
+
+function chunkBlobs(files: SnapshotFile[]): Blob[][] {
+  const unique = new Map<string, number>();
+  for (const file of files) {
+    if (file.oid && file.size !== undefined && !unique.has(file.oid)) {
+      unique.set(file.oid, file.size);
+    }
   }
 
-  try {
-    return git(cwd, ["show", `${snapshot.ref}:${file}`]);
-  } catch {
-    return null;
+  const chunks: Blob[][] = [];
+  let chunk: Blob[] = [];
+  let bytes = 0;
+  for (const [oid, size] of unique) {
+    if (chunk.length > 0 && bytes + size > BATCH_BYTES) {
+      chunks.push(chunk);
+      chunk = [];
+      bytes = 0;
+    }
+    chunk.push({ oid, size });
+    bytes += size;
   }
+  if (chunk.length > 0) chunks.push(chunk);
+  return chunks;
+}
+
+function readBlobBatch(cwd: string, batch: Blob[]): Map<string, string> {
+  const input = Buffer.from(`${batch.map((blob) => blob.oid).join("\n")}\n`);
+  const bytes = batch.reduce((total, blob) => total + blob.size, 0);
+  const maxBuffer = bytes + batch.length * 128 + 1024;
+  const output = gitBuffer(cwd, ["cat-file", "--batch"], input, maxBuffer);
+  const blobs = new Map<string, string>();
+  let offset = 0;
+
+  while (offset < output.length) {
+    const headerEnd = output.indexOf(0x0a, offset);
+    if (headerEnd < 0) throw new Error("Invalid git cat-file response");
+
+    const header = output.subarray(offset, headerEnd).toString("ascii");
+    const [oid, type, sizeText] = header.split(" ");
+    const size = Number(sizeText);
+    if (!oid || type !== "blob" || !Number.isInteger(size)) {
+      throw new Error(`Invalid git cat-file header: ${header}`);
+    }
+
+    const contentStart = headerEnd + 1;
+    const contentEnd = contentStart + size;
+    if (contentEnd >= output.length) {
+      throw new Error(`Truncated git blob: ${oid}`);
+    }
+
+    blobs.set(oid, output.subarray(contentStart, contentEnd).toString("utf8"));
+    offset = contentEnd + 1;
+  }
+
+  return blobs;
+}
+
+export function visitCommitBlobs(
+  cwd: string,
+  files: SnapshotFile[],
+  visit: (oid: string, source: string) => void,
+): void {
+  for (const batch of chunkBlobs(files)) {
+    for (const [oid, source] of readBlobBatch(cwd, batch)) {
+      visit(oid, source);
+    }
+  }
+}
+
+export function visitWorktreeFiles(
+  cwd: string,
+  files: SnapshotFile[],
+  visit: (file: SnapshotFile, source: string) => void,
+): void {
+  for (const file of files) {
+    const full = resolve(cwd, file.path);
+    if (!isRegularFile(full)) continue;
+    visit(file, readFileSync(full, "utf8"));
+  }
+}
+
+export function readSnapshotFiles(
+  cwd: string,
+  snapshot: Snapshot,
+  files: SnapshotFile[],
+): Map<string, string> {
+  const sources = new Map<string, string>();
+
+  if (snapshot.kind === "worktree") {
+    visitWorktreeFiles(cwd, files, (file, source) => {
+      sources.set(file.path, source);
+    });
+    return sources;
+  }
+
+  const pathsByOid = new Map<string, string[]>();
+  for (const file of files) {
+    if (!file.oid) continue;
+    const paths = pathsByOid.get(file.oid) ?? [];
+    paths.push(file.path);
+    pathsByOid.set(file.oid, paths);
+  }
+  visitCommitBlobs(cwd, files, (oid, source) => {
+    for (const path of pathsByOid.get(oid) ?? []) {
+      sources.set(path, source);
+    }
+  });
+  return sources;
 }
 
 export function describeSnapshot(snapshot: Snapshot): string {

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -1,17 +1,76 @@
 import type { FunctionIndex } from "./extract.js";
+import { flattenCallKeys } from "./extract.js";
 import { buildCallTree, resolveEntry } from "./calltree.js";
 import { diffTrees, treeHasChanges } from "./diff.js";
-import type { DiffNode } from "./types.js";
+import type { DiffNode, FunctionInfo } from "./types.js";
 
-function calleeSet(index: FunctionIndex, key: string, maxDepth: number): string {
-  const tree = buildCallTree(key, index, maxDepth);
-  const parts: string[] = [];
-  const walk = (node: typeof tree, depth: number) => {
-    parts.push(`${"  ".repeat(depth)}${node.key}`);
-    for (const child of node.children) walk(child, depth + 1);
-  };
-  walk(tree, 0);
-  return parts.join("\n");
+function functionShape(fn: FunctionInfo | undefined): string | null {
+  if (!fn) return null;
+  return JSON.stringify({ label: fn.label, steps: fn.steps });
+}
+
+function addReverseEdges(
+  reverse: Map<string, Set<string>>,
+  index: FunctionIndex,
+): void {
+  for (const [caller, fn] of index) {
+    for (const callee of flattenCallKeys(fn.steps)) {
+      let callers = reverse.get(callee);
+      if (!callers) {
+        callers = new Set();
+        reverse.set(callee, callers);
+      }
+      callers.add(caller);
+    }
+  }
+}
+
+function findAffected(
+  before: FunctionIndex,
+  after: FunctionIndex,
+  maxDepth: number,
+): Set<string> {
+  const keys = new Set([...before.keys(), ...after.keys()]);
+  const reverse = new Map<string, Set<string>>();
+  addReverseEdges(reverse, before);
+  addReverseEdges(reverse, after);
+
+  const distance = new Map<string, number>();
+  const queue: string[] = [];
+
+  for (const key of keys) {
+    if (functionShape(before.get(key)) === functionShape(after.get(key))) {
+      continue;
+    }
+    distance.set(key, 0);
+    queue.push(key);
+  }
+
+  for (let i = 0; i < queue.length; i += 1) {
+    const callee = queue[i]!;
+    const nextDistance = distance.get(callee)! + 1;
+    if (nextDistance > maxDepth) continue;
+
+    for (const caller of reverse.get(callee) ?? []) {
+      const previous = distance.get(caller);
+      if (previous !== undefined && previous <= nextDistance) continue;
+      distance.set(caller, nextDistance);
+      queue.push(caller);
+    }
+  }
+
+  return new Set(distance.keys());
+}
+
+function changedKeys(
+  keys: string[],
+  before: FunctionIndex,
+  after: FunctionIndex,
+  maxDepth: number,
+): string[] {
+  return keys
+    .filter((key) => diffEntry(key, before, after, maxDepth) !== null)
+    .sort((a, b) => a.localeCompare(b));
 }
 
 /**
@@ -25,55 +84,27 @@ export function inferEntries(
   maxDepth: number,
 ): string[] {
   if (explicit.length > 0) {
-    const resolved: string[] = [];
+    const entries: string[] = [];
     for (const entry of explicit) {
-      const fromBefore = resolveEntry(entry, before);
-      const fromAfter = resolveEntry(entry, after);
-      const key = fromAfter ?? fromBefore;
-      if (!key) {
-        throw new Error(`Entrypoint not found: ${entry}`);
-      }
-      if (!resolved.includes(key)) resolved.push(key);
+      const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
+      if (!key) throw new Error(`Entrypoint not found: ${entry}`);
+      if (!entries.includes(key)) entries.push(key);
     }
-    return resolved;
+    return entries;
   }
 
-  const keys = new Set([...before.keys(), ...after.keys()]);
-  const candidates: string[] = [];
+  const affected = [...findAffected(before, after, maxDepth)].filter(
+    (key) => !key.startsWith("new "),
+  );
+  const exported = affected.filter((key) =>
+    Boolean(before.get(key)?.exported || after.get(key)?.exported),
+  );
+  const entries = changedKeys(exported, before, after, maxDepth);
+  if (entries.length > 0) return entries;
 
-  for (const key of keys) {
-    // Skip synthetic `new X` aliases for inference listing (still resolvable)
-    if (key.startsWith("new ")) continue;
-
-    const b = before.get(key);
-    const a = after.get(key);
-
-    // Prefer exported / public-ish roots
-    const interesting = Boolean(b?.exported || a?.exported);
-    if (!interesting) continue;
-
-    const beforeTree = b ? calleeSet(before, key, maxDepth) : "";
-    const afterTree = a ? calleeSet(after, key, maxDepth) : "";
-
-    if (beforeTree !== afterTree) {
-      candidates.push(key);
-    }
-  }
-
-  // If nothing exported changed, fall back to any function with a differing tree
-  if (candidates.length === 0) {
-    for (const key of keys) {
-      if (key.startsWith("new ")) continue;
-      const beforeTree = before.has(key)
-        ? calleeSet(before, key, maxDepth)
-        : "";
-      const afterTree = after.has(key) ? calleeSet(after, key, maxDepth) : "";
-      if (beforeTree !== afterTree) candidates.push(key);
-    }
-  }
-
-  // Prefer shallower / shorter names first for stable output
-  return candidates.sort((a, b) => a.localeCompare(b));
+  const checked = new Set(exported);
+  const fallback = affected.filter((key) => !checked.has(key));
+  return changedKeys(fallback, before, after, maxDepth);
 }
 
 export function diffEntry(

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,26 +1,29 @@
 import { buildCallTree, resolveEntry } from "./calltree.js";
-import { buildIndex, extractFunctions } from "./extract.js";
+import { buildIndex, extractCached } from "./extract.js";
 import {
   assertGitRepo,
   describeSnapshot,
-  listTsFiles,
-  readSnapshotFile,
+  listSnapshotFiles,
   resolveDiffSnapshotsAndPaths,
   resolveSnapshotAndPaths,
   verifyCommit,
+  visitCommitBlobs,
+  visitWorktreeFiles,
 } from "./git.js";
 import { diffEntry, inferEntries } from "./infer.js";
 import { findReachPaths } from "./reach.js";
 import { renderDiff, renderTree } from "./render.js";
+import type { ExtractionCache, FunctionIndex } from "./extract.js";
+import type { SnapshotFile } from "./git.js";
 import type {
   CallNode,
   DiffNode,
   DiffResult,
+  FunctionInfo,
   ReachResult,
   Snapshot,
   TreeResult,
 } from "./types.js";
-import type { FunctionIndex } from "./extract.js";
 
 export type DiffRunOptions = {
   from?: string;
@@ -62,20 +65,41 @@ function loadIndex(
   cwd: string,
   snapshot: Snapshot,
   pathFilters: string[],
+  cache: ExtractionCache = new Map(),
 ): FunctionIndex {
-  const files = listTsFiles(cwd, snapshot, pathFilters);
-  const all = [];
-  for (const file of files) {
-    const source = readSnapshotFile(cwd, snapshot, file);
-    if (source === null) continue;
+  const files = listSnapshotFiles(cwd, snapshot, pathFilters);
+  const extracted = new Map<string, FunctionInfo[]>();
+  const extract = (file: SnapshotFile, source: string): void => {
     try {
-      all.push(...extractFunctions(file, source));
+      extracted.set(file.path, extractCached(file.path, source, cache));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`warn: failed to parse ${file} @ ${snapshot.ref}: ${message}`);
+      console.error(
+        `warn: failed to parse ${file.path} @ ${snapshot.ref}: ${message}`,
+      );
     }
+  };
+
+  if (snapshot.kind === "worktree") {
+    visitWorktreeFiles(cwd, files, extract);
+  } else {
+    const filesByOid = new Map<string, SnapshotFile[]>();
+    for (const file of files) {
+      if (!file.oid) continue;
+      const matches = filesByOid.get(file.oid) ?? [];
+      matches.push(file);
+      filesByOid.set(file.oid, matches);
+    }
+    visitCommitBlobs(cwd, files, (oid, source) => {
+      for (const file of filesByOid.get(oid) ?? []) extract(file, source);
+    });
   }
-  return buildIndex(all);
+
+  const functions: FunctionInfo[] = [];
+  for (const file of files) {
+    functions.push(...(extracted.get(file.path) ?? []));
+  }
+  return buildIndex(functions);
 }
 
 function resolveEntries(index: FunctionIndex, explicit: string[]): string[] {
@@ -138,8 +162,10 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   if (from.kind === "commit") verifyCommit(cwd, from.ref);
   if (to.kind === "commit") verifyCommit(cwd, to.ref);
 
-  const before = loadIndex(cwd, from, resolvedPaths);
-  const after = loadIndex(cwd, to, resolvedPaths);
+  const extractionCache: ExtractionCache = new Map();
+  const before = loadIndex(cwd, from, resolvedPaths, extractionCache);
+  const after = loadIndex(cwd, to, resolvedPaths, extractionCache);
+  extractionCache.clear();
 
   const entries = inferEntries(before, after, entriesOpt, maxDepth);
 

--- a/test/extract-cache.test.ts
+++ b/test/extract-cache.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import { extractCached } from "../src/extract.js";
+import type { ExtractionCache } from "../src/extract.js";
+
+const source = "export function run() { return work(); }\n";
+
+test("reuses extraction for the same path and source", () => {
+  const cache: ExtractionCache = new Map();
+
+  const before = extractCached("src/file.ts", source, cache);
+  const after = extractCached("src/file.ts", source, cache);
+
+  expect(cache.size).toBe(1);
+  expect(after).toEqual(before);
+});
+
+test("does not share path-dependent extraction results", () => {
+  const cache: ExtractionCache = new Map();
+
+  extractCached("src/before.ts", source, cache);
+  extractCached("src/after.ts", source, cache);
+
+  expect(cache.size).toBe(2);
+});
+
+test("does not share extraction across different languages", () => {
+  const cache: ExtractionCache = new Map();
+
+  extractCached("file.ts", source, cache);
+  extractCached("file.tsx", source, cache);
+
+  expect(cache.size).toBe(2);
+});

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,0 +1,144 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, test } from "vitest";
+import {
+  listSnapshotFiles,
+  readSnapshotFiles,
+} from "../src/git.js";
+import type { Snapshot } from "../src/types.js";
+
+const tempDirs: string[] = [];
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+
+function makeRepo(): string {
+  const cwd = mkdtempSync(join(tmpdir(), "calldiff-git-"));
+  tempDirs.push(cwd);
+  execFileSync("git", ["init", "-q"], { cwd });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd });
+  return cwd;
+}
+
+function commitAll(cwd: string): void {
+  execFileSync("git", ["add", "-A"], { cwd });
+  execFileSync("git", ["commit", "-qm", "fixture"], { cwd });
+}
+
+function runCli(cwd: string, args: string[]): string {
+  return execFileSync(
+    process.execPath,
+    [
+      join(projectRoot, "node_modules/tsx/dist/cli.mjs"),
+      join(projectRoot, "src/cli.ts"),
+      ...args,
+    ],
+    {
+      cwd,
+      encoding: "utf8",
+    },
+  );
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runs a commit-to-commit diff end to end", () => {
+  const cwd = makeRepo();
+  writeFileSync(
+    join(cwd, "app.ts"),
+    "export function root() { beforeCall(); }\n",
+  );
+  commitAll(cwd);
+  const before = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+
+  writeFileSync(
+    join(cwd, "app.ts"),
+    "export function root() { afterCall(); }\n",
+  );
+  commitAll(cwd);
+
+  const output = runCli(cwd, ["diff", before, "HEAD", "--entry", "root"]);
+  expect(output).toContain("- ├─ beforeCall()");
+  expect(output).toContain("+ └─ afterCall()");
+});
+
+test("lists tracked and non-ignored worktree sources", () => {
+  const cwd = makeRepo();
+  mkdirSync(join(cwd, ".config"));
+  writeFileSync(join(cwd, ".gitignore"), "ignored/\n");
+  writeFileSync(join(cwd, ".config/tracked.ts"), "export const tracked = 1;\n");
+  writeFileSync(join(cwd, "deleted.ts"), "export const deleted = 1;\n");
+  commitAll(cwd);
+
+  rmSync(join(cwd, "deleted.ts"));
+  mkdirSync(join(cwd, "ignored"));
+  writeFileSync(join(cwd, "ignored/skip.ts"), "export const skip = 1;\n");
+  writeFileSync(join(cwd, "untracked.ts"), "export const untracked = 1;\n");
+
+  const snapshot: Snapshot = { kind: "worktree", ref: "WORKTREE" };
+  const files = listSnapshotFiles(cwd, snapshot);
+  const sources = readSnapshotFiles(cwd, snapshot, files);
+
+  expect(files.map((file) => file.path)).toEqual([
+    ".config/tracked.ts",
+    "untracked.ts",
+  ]);
+  expect([...sources.keys()]).toEqual([
+    ".config/tracked.ts",
+    "untracked.ts",
+  ]);
+});
+
+test.skipIf(process.platform === "win32")(
+  "skips source-shaped symlinks in commits and the worktree",
+  () => {
+    const cwd = makeRepo();
+    writeFileSync(join(cwd, "source.txt"), "export function linked() {}\n");
+    symlinkSync("source.txt", join(cwd, "linked.ts"));
+    commitAll(cwd);
+
+    const commit: Snapshot = { kind: "commit", ref: "HEAD" };
+    const worktree: Snapshot = { kind: "worktree", ref: "WORKTREE" };
+
+    expect(listSnapshotFiles(cwd, commit)).toEqual([]);
+    expect(listSnapshotFiles(cwd, worktree)).toEqual([]);
+  },
+);
+
+test("reads commit source blobs in a batch", () => {
+  const cwd = makeRepo();
+  const oddPath = "src/line\nbreak.ts";
+  mkdirSync(join(cwd, "src"));
+  writeFileSync(join(cwd, "src/main.ts"), 'export const café = "☕";\n');
+  writeFileSync(join(cwd, oddPath), "export function odd() {}\n");
+  writeFileSync(join(cwd, "src/types.d.ts"), "declare const ignored: string;\n");
+  writeFileSync(join(cwd, "README.md"), "not source\n");
+  commitAll(cwd);
+
+  const snapshot: Snapshot = { kind: "commit", ref: "HEAD" };
+  const files = listSnapshotFiles(cwd, snapshot);
+  const sources = readSnapshotFiles(cwd, snapshot, files);
+
+  expect(files.map((file) => file.path)).toEqual([
+    oddPath,
+    "src/main.ts",
+  ]);
+  expect(files.every((file) => Boolean(file.oid))).toBe(true);
+  expect(sources.get("src/main.ts")).toBe('export const café = "☕";\n');
+  expect(sources.get(oddPath)).toBe("export function odd() {}\n");
+});

--- a/test/infer.test.ts
+++ b/test/infer.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest";
+import { inferEntries } from "../src/infer.js";
+import type { FunctionIndex } from "../src/extract.js";
+import type { FunctionInfo } from "../src/types.js";
+
+function fn(
+  key: string,
+  calls: string[],
+  exported = false,
+): FunctionInfo {
+  return {
+    key,
+    label: `${key}()`,
+    file: "file.ts",
+    steps: calls.map((call) => ({ type: "call", key: call })),
+    exported,
+    start: 0,
+    end: 1,
+  };
+}
+
+function index(...functions: FunctionInfo[]): FunctionIndex {
+  return new Map(functions.map((fn) => [fn.key, fn]));
+}
+
+test("infers only exported ancestors of changed functions", () => {
+  const before = index(
+    fn("changed", ["oldCall"]),
+    fn("changedRoot", ["changed"], true),
+    fn("stable", ["sameCall"]),
+    fn("stableRoot", ["stable"], true),
+  );
+  const after = index(
+    fn("changed", ["newCall"]),
+    fn("changedRoot", ["changed"], true),
+    fn("stable", ["sameCall"]),
+    fn("stableRoot", ["stable"], true),
+  );
+
+  expect(inferEntries(before, after, [], 12)).toEqual(["changedRoot"]);
+});
+
+test("falls back to changed non-exported functions", () => {
+  const before = index(fn("worker", ["oldCall"]));
+  const after = index(fn("worker", ["newCall"]));
+
+  expect(inferEntries(before, after, [], 12)).toEqual(["worker"]);
+});
+
+test("retains explicit unchanged entries without a diff", () => {
+  const before = index(fn("root", ["sameCall"], true));
+  const after = index(fn("root", ["sameCall"], true));
+
+  expect(inferEntries(before, after, ["root"], 12)).toEqual(["root"]);
+});


### PR DESCRIPTION
## Summary

- batch commit reads with `git cat-file --batch`
- reuse extraction results for unchanged files
- respect Git ignore rules and handle symlinks consistently
- prune entrypoint inference using reverse-call reachability
- bound source and call-tree memory

## Performance

A quick 240-file synthetic benchmark was roughly 12× faster. This was not a controlled benchmark, so treat it as directional rather than a reliable performance claim.

## Testing

- `npm run build`
- `npx vitest run --maxWorkers=1 --testTimeout=60000`
