### PR TITLE
Add repository-wide call snapshots for agents and humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,54 @@ calldiff main feature -e PiService.createAgentSession -e boot
 calldiff main feature -- src/lib
 ```
 
+### Repository call snapshot
+
+Generate every extracted function and its direct call/branch structure from one
+commit, rather than a diff rooted at one entrypoint:
+
+```bash
+calldiff --snapshot HEAD --output .calldiff/head -- src
+
+# Canonical machine record for agents, jq, or Neovim
+nvim .calldiff/head/calldiff-call-snapshot.json
+jq '.summary' .calldiff/head/calldiff-call-snapshot.json
+
+# Searchable, collapsible, syntax-colored human projection
+open .calldiff/head/calldiff-call-snapshot.html       # macOS
+xdg-open .calldiff/head/calldiff-call-snapshot.html  # Linux
+```
+
+The JSON file is authoritative. The HTML file is derived from the same record
+and links back to it. Calls report `unique-key-match`, `multiple-key-matches`,
+or `no-key-match`; these are syntactic matches within the selected files that
+parsed successfully, not type resolution. A missing key match does not prove
+that a call is external. The output directory must be new, so a later run cannot
+overwrite prior evidence.
+
+### Frozen-file library API
+
+Integrators can analyze exact retained bytes without letting calldiff read a
+repository or worktree:
+
+```ts
+import {
+  analyzeRepositoryFiles,
+  diffRepositoryCallSnapshots,
+  projectRepositoryCallSnapshot,
+} from "calldiff";
+
+const before = analyzeRepositoryFiles(beforeFiles, "subject/before");
+const after = analyzeRepositoryFiles(afterFiles, "subject/after");
+const delta = diffRepositoryCallSnapshots(before, after);
+const localView = projectRepositoryCallSnapshot(after, ["src/cli.ts"]);
+```
+
+`analyzeRepositoryFiles` accepts `{ path, content }` records. The caller owns
+selection and freezing. A projection includes selected definitions, direct
+syntactic key matches, direct callers, diagnostics, and an omitted-definition
+count.
+The canonical snapshot remains the source of truth.
+
 ### Semantics (git-diff shaped)
 
 | Invocation | From | To |

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.1.0",
   "description": "Diff call stacks across git commits for agentic code review (22 languages)",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "calldiff": "./dist/cli.js"
   },
@@ -11,6 +19,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "dev": "tsx src/cli.ts",
     "start": "node dist/cli.js",

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,8 @@
-import type { CliOptions } from "./types.js";
+import type {
+  CliOptions,
+  DiffCliOptions,
+  SnapshotCliOptions,
+} from "./types.js";
 
 function takeValue(argv: string[], i: number, flag: string): [string, number] {
   const next = argv[i + 1];
@@ -8,16 +12,62 @@ function takeValue(argv: string[], i: number, flag: string): [string, number] {
   return [next, i + 1];
 }
 
-/**
- * Git-diff-shaped args:
- *   calldiff
- *   calldiff <from>
- *   calldiff <from> <to>
- *   calldiff --from <ref> --to <ref>
- *   calldiff ... --entry Name [--entry Class.method] -- [paths...]
- */
+function optionArguments(argv: string[]): string[] {
+  const pathSeparator = argv.indexOf("--");
+  return pathSeparator < 0 ? argv : argv.slice(0, pathSeparator);
+}
+
+function hasSnapshotFlag(argv: string[]): boolean {
+  return optionArguments(argv).includes("--snapshot");
+}
+
+function parseSnapshotArgs(argv: string[], cwd: string): SnapshotCliOptions {
+  const options: SnapshotCliOptions = {
+    command: "snapshot",
+    ref: "HEAD",
+    paths: [],
+    cwd,
+    help:
+      optionArguments(argv).includes("-h") ||
+      optionArguments(argv).includes("--help"),
+  };
+  if (options.help) return options;
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i]!;
+    if (arg === "--") {
+      options.paths.push(...argv.slice(i + 1));
+      break;
+    }
+    if (arg === "--snapshot") {
+      const [value, next] = takeValue(argv, i, arg);
+      options.ref = value;
+      i = next + 1;
+      continue;
+    }
+    if (arg === "--output" || arg === "-o") {
+      const [value, next] = takeValue(argv, i, arg);
+      options.output = value;
+      i = next + 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown snapshot option: ${arg}`);
+    }
+    throw new Error(`Unexpected snapshot argument: ${arg}`);
+  }
+  return options;
+}
+
+/** Parse snapshot flags or the default git-diff-shaped command. */
 export function parseArgs(argv: string[], cwd = process.cwd()): CliOptions {
-  const options: CliOptions = {
+  if (hasSnapshotFlag(argv)) {
+    return parseSnapshotArgs(argv, cwd);
+  }
+
+  const options: DiffCliOptions = {
+    command: "diff",
     entries: [],
     paths: [],
     cwd,
@@ -113,6 +163,7 @@ Usage:
   calldiff <from> <to>
   calldiff --from <ref> --to <ref>
   calldiff [refs] --entry <name> [--entry <Class.method>] [-- paths...]
+  calldiff --snapshot <ref> --output <directory> [-- paths...]
 
 Semantics (like git diff):
   (no refs)     from=HEAD, to=working tree
@@ -125,7 +176,13 @@ Options:
   -e, --entry <name> Entrypoint(s): functionName or ClassName.method
                      If omitted, infer exported functions whose call trees changed
   --max-depth <n>    Max call-tree depth (default: 12)
+  --snapshot <ref>   Write one repository call snapshot instead of a diff
+  -o, --output <dir> New snapshot output directory (with --snapshot)
   -h, --help         Show help
+
+Snapshot output:
+  calldiff-call-snapshot.json   Canonical machine record
+  calldiff-call-snapshot.html   Searchable human projection
 
 Labels:
   functionName

--- a/src/git.ts
+++ b/src/git.ts
@@ -6,18 +6,23 @@ import type { Snapshot } from "./types.js";
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd,
+    env: { ...process.env, GIT_NO_REPLACE_OBJECTS: "1" },
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
   });
 }
 
-export function assertGitRepo(cwd: string): void {
+export function repositoryRoot(cwd: string): string {
   try {
-    git(cwd, ["rev-parse", "--is-inside-work-tree"]);
+    return git(cwd, ["rev-parse", "--show-toplevel"]).trim();
   } catch {
     throw new Error(`Not a git repository: ${cwd}`);
   }
+}
+
+export function assertGitRepo(cwd: string): void {
+  repositoryRoot(cwd);
 }
 
 export function resolveSnapshots(
@@ -36,12 +41,16 @@ export function resolveSnapshots(
   return { from: left, to: right };
 }
 
-export function verifyCommit(cwd: string, ref: string): void {
+export function resolveCommit(cwd: string, ref: string): string {
   try {
-    git(cwd, ["rev-parse", "--verify", `${ref}^{commit}`]);
+    return git(cwd, ["rev-parse", "--verify", `${ref}^{commit}`]).trim();
   } catch {
     throw new Error(`Unknown git ref: ${ref}`);
   }
+}
+
+export function verifyCommit(cwd: string, ref: string): void {
+  resolveCommit(cwd, ref);
 }
 
 import { listSupportedExtensions } from "./languages/registry.js";
@@ -89,23 +98,39 @@ function walkWorktree(root: string, dir: string, out: string[]): void {
 }
 
 function listCommitSourceFiles(cwd: string, ref: string): string[] {
-  const output = git(cwd, ["ls-tree", "-r", "--name-only", ref]);
+  const output = git(cwd, [
+    "ls-tree",
+    "-rz",
+    "--full-tree",
+    "--name-only",
+    ref,
+  ]);
   return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line && isSourceFile(line));
+    .split("\0")
+    .filter((file) => file.length > 0 && isSourceFile(file));
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Normalize CLI filters to sorted repository-relative `/` paths. */
+export function normalizePathFilters(pathFilters: string[]): string[] {
+  const normalized = pathFilters.map((filter) =>
+    filter
+      .replaceAll("\\", "/")
+      .replace(/^\.\/+/, "")
+      .replace(/\/+$/, ""),
+  );
+  if (normalized.some((filter) => filter === "" || filter === ".")) return [];
+  return [...new Set(normalized)].sort(compareText);
 }
 
 function pathAllowed(file: string, pathFilters: string[]): boolean {
   if (pathFilters.length === 0) return true;
-  return pathFilters.some((filter) => {
-    const normalized = filter.replace(/^\.\//, "").replace(/\/$/, "");
-    return (
-      file === normalized ||
-      file.startsWith(`${normalized}/`) ||
-      file.endsWith(normalized)
-    );
-  });
+  return pathFilters.some(
+    (filter) => file === filter || file.startsWith(`${filter}/`),
+  );
 }
 
 /** @deprecated Use listSourceFiles */
@@ -131,7 +156,8 @@ export function listSourceFiles(
         })()
       : listCommitSourceFiles(cwd, snapshot.ref);
 
-  return files.filter((file) => pathAllowed(file, pathFilters)).sort();
+  const normalizedFilters = normalizePathFilters(pathFilters);
+  return files.filter((file) => pathAllowed(file, normalizedFilters)).sort();
 }
 
 export function readSnapshotFile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,19 @@ export { buildCallTree, resolveEntry } from "./calltree.js";
 export { diffTrees, treeHasChanges } from "./diff.js";
 export { buildIndex, extractFunctions } from "./extract.js";
 export { renderDiff } from "./render.js";
+export {
+  analyzeRepositoryFiles,
+  diffRepositoryCallSnapshots,
+  projectRepositoryCallSnapshot,
+  REPOSITORY_CALL_DELTA_SCHEMA,
+  REPOSITORY_CALL_PROJECTION_SCHEMA,
+} from "./repository-analysis.js";
+export {
+  buildRepositoryCallSnapshot,
+  REPOSITORY_CALL_SNAPSHOT_SCHEMA,
+} from "./repository-snapshot.js";
+export { listSupportedExtensions, listSupportedLanguages } from "./languages/registry.js";
 export { run } from "./run.js";
+export type * from "./repository-analysis.js";
+export type * from "./repository-snapshot.js";
 export type * from "./types.js";

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,0 +1,55 @@
+import { extractFunctions } from "./extract.js";
+import { listSourceFiles, readSnapshotFile } from "./git.js";
+import type { FunctionInfo, Snapshot } from "./types.js";
+
+export interface ParseDiagnostic {
+  file: string;
+  message: string;
+}
+
+export interface LoadFunctionsOptions {
+  failOnReadError?: boolean;
+}
+
+export interface LoadedFunctions {
+  files: string[];
+  functions: FunctionInfo[];
+  sources: Map<string, string>;
+  diagnostics: ParseDiagnostic[];
+}
+
+/** Load every supported source file from one repository snapshot. */
+export function loadFunctions(
+  cwd: string,
+  snapshot: Snapshot,
+  pathFilters: string[],
+  options: LoadFunctionsOptions = {},
+): LoadedFunctions {
+  const files = listSourceFiles(cwd, snapshot, pathFilters);
+  const functions: FunctionInfo[] = [];
+  const sources = new Map<string, string>();
+  const diagnostics: ParseDiagnostic[] = [];
+
+  for (const file of files) {
+    const source = readSnapshotFile(cwd, snapshot, file);
+    if (source === null) {
+      const message = "source file could not be read";
+      if (options.failOnReadError) {
+        throw new Error(`${message}: ${file} @ ${snapshot.ref}`);
+      }
+      diagnostics.push({ file, message });
+      continue;
+    }
+    sources.set(file, source);
+    try {
+      functions.push(...extractFunctions(file, source));
+    } catch (error) {
+      diagnostics.push({
+        file,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { files, functions, sources, diagnostics };
+}

--- a/src/repository-analysis.ts
+++ b/src/repository-analysis.ts
@@ -1,0 +1,215 @@
+import { createHash } from "node:crypto";
+import { extractFunctions } from "./extract.js";
+import { detectLanguage } from "./languages/registry.js";
+import type { LoadedFunctions, ParseDiagnostic } from "./load.js";
+import type { FunctionInfo } from "./types.js";
+import {
+  buildRepositoryCallSnapshot,
+  type RepositoryCallSnapshot,
+  type RepositoryCallSource,
+  type RepositoryDefinition,
+} from "./repository-snapshot.js";
+
+export interface FrozenRepositoryFile {
+  path: string;
+  content: string;
+}
+
+export const REPOSITORY_CALL_DELTA_SCHEMA =
+  "calldiff-repository-call-delta/1" as const;
+export const REPOSITORY_CALL_PROJECTION_SCHEMA =
+  "calldiff-repository-call-projection/1" as const;
+
+export interface RepositoryDefinitionChange {
+  matchId: string;
+  change: "added" | "removed" | "changed";
+  before?: RepositoryDefinition;
+  after?: RepositoryDefinition;
+}
+
+export interface RepositoryCallDelta {
+  schema: typeof REPOSITORY_CALL_DELTA_SCHEMA;
+  before: RepositoryCallSource;
+  after: RepositoryCallSource;
+  summary: {
+    addedDefinitions: number;
+    removedDefinitions: number;
+    changedDefinitions: number;
+    unchangedDefinitions: number;
+  };
+  changes: RepositoryDefinitionChange[];
+}
+
+export interface RepositoryCallProjection {
+  schema: typeof REPOSITORY_CALL_PROJECTION_SCHEMA;
+  source: RepositoryCallSource;
+  selectedFiles: string[];
+  includedFiles: string[];
+  omittedDefinitions: number;
+  definitions: RepositoryDefinition[];
+  diagnostics: ParseDiagnostic[];
+}
+
+const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+const sha256 = (value: string): string =>
+  createHash("sha256").update(value).digest("hex");
+
+/** Analyze exact frozen file contents without reading a repository or worktree. */
+export function analyzeRepositoryFiles(
+  files: readonly FrozenRepositoryFile[],
+  subjectId: string,
+): RepositoryCallSnapshot {
+  const ordered = [...files]
+    .map((file) => ({ path: file.path.replaceAll("\\", "/"), content: file.content }))
+    .sort((left, right) => compareText(left.path, right.path));
+  const duplicate = ordered.find(
+    (file, index) => index > 0 && ordered[index - 1]!.path === file.path,
+  );
+  if (duplicate) throw new Error(`Duplicate frozen file path: ${duplicate.path}`);
+
+  const supported = ordered.filter((file) => detectLanguage(file.path));
+  const functions: FunctionInfo[] = [];
+  const diagnostics: ParseDiagnostic[] = [];
+  for (const file of supported) {
+    try {
+      functions.push(...extractFunctions(file.path, file.content));
+    } catch (error) {
+      diagnostics.push({
+        file: file.path,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  const loaded: LoadedFunctions = {
+    files: supported.map((file) => file.path),
+    functions,
+    sources: new Map(supported.map((file) => [file.path, file.content])),
+    diagnostics,
+  };
+  return buildRepositoryCallSnapshot(loaded, {
+    kind: "frozen-files",
+    subjectId,
+    fileDigests: supported.map((file) => ({
+      path: file.path,
+      sha256: sha256(file.content),
+    })),
+  });
+}
+
+function matchedDefinitions(
+  definitions: readonly RepositoryDefinition[],
+): Map<string, RepositoryDefinition> {
+  const counts = new Map<string, number>();
+  const matched = new Map<string, RepositoryDefinition>();
+  for (const definition of definitions) {
+    const base = `${definition.file}:${definition.key}`;
+    const ordinal = (counts.get(base) ?? 0) + 1;
+    counts.set(base, ordinal);
+    matched.set(`${base}#${ordinal}`, definition);
+  }
+  return matched;
+}
+
+function structure(definition: RepositoryDefinition): string {
+  return JSON.stringify({ exported: definition.exported, steps: definition.steps });
+}
+
+/** Compare two retained call snapshots without parsing source again. */
+export function diffRepositoryCallSnapshots(
+  before: RepositoryCallSnapshot,
+  after: RepositoryCallSnapshot,
+): RepositoryCallDelta {
+  const beforeById = matchedDefinitions(before.definitions);
+  const afterById = matchedDefinitions(after.definitions);
+  const ids = [...new Set([...beforeById.keys(), ...afterById.keys()])].sort(
+    compareText,
+  );
+  const changes: RepositoryDefinitionChange[] = [];
+  let unchangedDefinitions = 0;
+
+  for (const matchId of ids) {
+    const previous = beforeById.get(matchId);
+    const next = afterById.get(matchId);
+    if (!previous) {
+      changes.push({ matchId, change: "added", after: next });
+    } else if (!next) {
+      changes.push({ matchId, change: "removed", before: previous });
+    } else if (structure(previous) !== structure(next)) {
+      changes.push({ matchId, change: "changed", before: previous, after: next });
+    } else {
+      unchangedDefinitions += 1;
+    }
+  }
+
+  return {
+    schema: REPOSITORY_CALL_DELTA_SCHEMA,
+    before: before.source,
+    after: after.source,
+    summary: {
+      addedDefinitions: changes.filter((change) => change.change === "added").length,
+      removedDefinitions: changes.filter((change) => change.change === "removed").length,
+      changedDefinitions: changes.filter((change) => change.change === "changed").length,
+      unchangedDefinitions,
+    },
+    changes,
+  };
+}
+
+function visitsTarget(
+  definition: RepositoryDefinition,
+  matchingDefinitionIds: ReadonlySet<string>,
+): boolean {
+  const pending = [...definition.steps];
+  while (pending.length) {
+    const step = pending.pop()!;
+    if (step.type === "branch") pending.push(...step.children);
+    else if (
+      step.matchingDefinitionIds.some((id) => matchingDefinitionIds.has(id))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Select definitions from named files plus direct key matches and callers.
+ * The canonical snapshot remains authoritative and records omitted counts.
+ */
+export function projectRepositoryCallSnapshot(
+  snapshot: RepositoryCallSnapshot,
+  selectedFiles: readonly string[],
+): RepositoryCallProjection {
+  const selected = new Set(selectedFiles.map((path) => path.replaceAll("\\", "/")));
+  const seeds = snapshot.definitions.filter((definition) => selected.has(definition.file));
+  const seedIds = new Set(seeds.map((definition) => definition.id));
+  const includedIds = new Set(seedIds);
+  const pending = [...seeds];
+  while (pending.length) {
+    const definition = pending.pop()!;
+    const steps = [...definition.steps];
+    while (steps.length) {
+      const step = steps.pop()!;
+      if (step.type === "branch") steps.push(...step.children);
+      else for (const id of step.matchingDefinitionIds) includedIds.add(id);
+    }
+  }
+  for (const definition of snapshot.definitions) {
+    if (visitsTarget(definition, seedIds)) includedIds.add(definition.id);
+  }
+  const definitions = snapshot.definitions.filter((definition) =>
+    includedIds.has(definition.id),
+  );
+  return {
+    schema: REPOSITORY_CALL_PROJECTION_SCHEMA,
+    source: snapshot.source,
+    selectedFiles: [...selected].sort(compareText),
+    includedFiles: [...new Set(definitions.map((definition) => definition.file))].sort(
+      compareText,
+    ),
+    omittedDefinitions: snapshot.definitions.length - definitions.length,
+    definitions,
+    diagnostics: snapshot.diagnostics,
+  };
+}

--- a/src/repository-snapshot-html.ts
+++ b/src/repository-snapshot-html.ts
@@ -1,0 +1,231 @@
+import type {
+  RepositoryCallSnapshot,
+  RepositoryCallStep,
+  RepositoryDefinition,
+} from "./repository-snapshot.js";
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function walkSteps(
+  steps: RepositoryCallStep[],
+  visit: (step: RepositoryCallStep) => void,
+): void {
+  for (const step of steps) {
+    visit(step);
+    if (step.type === "branch") walkSteps(step.children, visit);
+  }
+}
+
+/** Render the human projection of a canonical repository call snapshot. */
+export function renderRepositoryCallSnapshotHtml(
+  snapshot: RepositoryCallSnapshot,
+  jsonFilename: string,
+): string {
+  const byId = new Map(
+    snapshot.definitions.map((definition) => [definition.id, definition]),
+  );
+  const anchorById = new Map(
+    snapshot.definitions.map((definition, index) => [
+      definition.id,
+      `definition-${String(index + 1).padStart(4, "0")}`,
+    ]),
+  );
+  const definitionsByKey = new Map<string, RepositoryDefinition[]>();
+  for (const definition of snapshot.definitions) {
+    definitionsByKey.set(definition.key, [
+      ...(definitionsByKey.get(definition.key) ?? []),
+      definition,
+    ]);
+  }
+
+  const renderCall = (
+    step: Extract<RepositoryCallStep, { type: "call" }>,
+  ): string => {
+    const targets = step.matchingDefinitionIds
+      .map((id) => byId.get(id))
+      .filter((target): target is RepositoryDefinition => target !== undefined);
+    const label = `${step.key}${step.key.includes("(") ? "" : "()"}`;
+    let renderedLabel = `<span class="call-label">${escapeHtml(label)}</span>`;
+    if (targets.length === 1) {
+      renderedLabel = `<a class="call-label" href="#${anchorById.get(targets[0]!.id)}">${escapeHtml(label)}</a>`;
+    }
+    const targetLinks =
+      targets.length > 1
+        ? `<span class="targets">${targets
+            .map(
+              (target) =>
+                `<a href="#${anchorById.get(target.id)}">${escapeHtml(`${target.file}:${target.span.startLine}`)}</a>`,
+            )
+            .join(" · ")}</span>`
+        : "";
+    return `<li class="step call-step ${step.match}"><div class="step-row">${renderedLabel}<span class="badge ${step.match}">${escapeHtml(step.match)}</span>${targetLinks}</div></li>`;
+  };
+
+  const renderSteps = (steps: RepositoryCallStep[]): string => {
+    if (steps.length === 0) {
+      return '<div class="empty">No extracted calls or branches.</div>';
+    }
+    return `<ul class="steps">${steps
+      .map((step) => {
+        if (step.type === "call") return renderCall(step);
+        return `<li class="step branch-step"><details open><summary class="step-row"><span class="branch-label">${escapeHtml(step.label)}</span><span class="badge branch">branch</span><span class="count">${step.children.length}</span></summary>${renderSteps(step.children)}</details></li>`;
+      })
+      .join("")}</ul>`;
+  };
+
+  const searchableText = (definition: RepositoryDefinition): string => {
+    const parts = [
+      definition.file,
+      definition.language,
+      definition.key,
+      definition.label,
+    ];
+    walkSteps(definition.steps, (step) => {
+      parts.push(step.key);
+      if (step.type === "branch") parts.push(step.label);
+    });
+    return parts.join(" ").toLowerCase();
+  };
+
+  const renderDefinition = (definition: RepositoryDefinition): string => {
+    let calls = 0;
+    walkSteps(definition.steps, (step) => {
+      if (step.type === "call") calls += 1;
+    });
+    const collisionCount = definitionsByKey.get(definition.key)?.length ?? 1;
+    const collision =
+      collisionCount > 1
+        ? `<span class="badge ambiguous">${collisionCount} definitions share this key</span>`
+        : "";
+    const anchor = anchorById.get(definition.id);
+    return `<article class="definition" id="${anchor}" data-search="${escapeHtml(searchableText(definition))}"><details><summary class="definition-row"><span class="definition-label">${escapeHtml(definition.label)}</span>${definition.exported ? '<span class="badge exported">exported</span>' : ""}${collision}<span class="language">${escapeHtml(definition.language)}</span><span class="count">${calls} calls</span><span class="source">${escapeHtml(`${definition.file}:L${definition.span.startLine}–L${definition.span.endLine}`)}</span></summary><div class="definition-body">${renderSteps(definition.steps)}</div></details></article>`;
+  };
+
+  const recordsByFile = new Map<string, RepositoryDefinition[]>();
+  for (const definition of snapshot.definitions) {
+    recordsByFile.set(definition.file, [
+      ...(recordsByFile.get(definition.file) ?? []),
+      definition,
+    ]);
+  }
+  const fileSections = [...recordsByFile.entries()]
+    .map(
+      ([file, definitions]) =>
+        `<section class="file" data-file="${escapeHtml(file.toLowerCase())}"><details><summary class="file-row"><span>${escapeHtml(file)}</span><span class="count">${definitions.length} definitions</span></summary><div class="file-body">${definitions.map(renderDefinition).join("")}</div></details></section>`,
+    )
+    .join("");
+  const diagnostics =
+    snapshot.diagnostics.length === 0
+      ? ""
+      : `<details class="diagnostics"><summary>${snapshot.diagnostics.length} parse warnings</summary><ul>${snapshot.diagnostics.map((item) => `<li>${escapeHtml(item.file)}: ${escapeHtml(item.message)}</li>`).join("")}</ul></details>`;
+  const summary = snapshot.summary;
+  const sourceLabel =
+    snapshot.source.kind === "commit"
+      ? `commit ${snapshot.source.commit.slice(0, 12)}`
+      : `subject ${snapshot.source.subjectId}`;
+  const sourceDetails =
+    snapshot.source.kind === "commit"
+      ? [
+          `requested ${snapshot.source.requestedRef}`,
+          `scope ${snapshot.source.pathFilters.length > 0 ? snapshot.source.pathFilters.join(", ") : "all supported files"}`,
+        ]
+      : [`${snapshot.source.fileDigests.length} frozen files`];
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>calldiff repository call snapshot</title>
+<style>
+:root { color-scheme:dark; --bg:#0d1117; --panel:#161b22; --panel2:#21262d; --text:#c9d1d9; --muted:#8b949e; --line:#30363d; --call:#79c0ff; --branch:#d2a8ff; --internal:#3fb950; --ambiguous:#d29922; --external:#8b949e; --exported:#56d4dd; }
+* { box-sizing:border-box; }
+html { scroll-padding-top:150px; }
+body { margin:0; background:var(--bg); color:var(--text); font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+a { color:inherit; }
+header { position:sticky; top:0; z-index:3; padding:16px 24px; background:rgba(13,17,23,.96); border-bottom:1px solid var(--line); backdrop-filter:blur(8px); }
+h1 { margin:0 0 7px; color:#f0f6fc; font-size:18px; }
+.meta,.controls,.legend { display:flex; flex-wrap:wrap; gap:8px 16px; color:var(--muted); }
+.controls { margin-top:11px; gap:8px; }
+input { width:min(680px,100%); padding:8px 10px; color:var(--text); background:var(--panel); border:1px solid var(--line); border-radius:6px; font:inherit; }
+button { padding:8px 10px; color:var(--text); background:var(--panel2); border:1px solid var(--line); border-radius:6px; font:inherit; cursor:pointer; }
+main { max-width:1500px; padding:18px 24px 80px; }
+.notice,.diagnostics { margin-bottom:14px; padding:10px 12px; color:var(--muted); background:var(--panel); border-left:3px solid var(--ambiguous); }
+.legend { margin-bottom:14px; }
+.file { margin:8px 0; border:1px solid var(--line); border-radius:7px; overflow:hidden; }
+.file-row { padding:9px 12px; color:#f0f6fc; background:var(--panel); cursor:pointer; }
+.file-body { padding:6px 10px 10px; }
+.definition { margin:4px 0; border-left:2px solid var(--line); }
+.definition:target { border-left-color:var(--call); background:rgba(121,192,255,.06); }
+.definition-row { display:flex; flex-wrap:wrap; align-items:baseline; gap:8px; min-height:28px; padding:4px 8px; cursor:pointer; }
+.definition-row:hover,.step-row:hover { background:var(--panel); }
+.definition-label { color:#f0f6fc; }
+.definition-body { padding:3px 0 8px 22px; }
+.steps { list-style:none; margin:0; padding-left:18px; border-left:1px solid var(--line); }
+.step { margin:2px 0; }
+.step-row { display:flex; flex-wrap:wrap; align-items:baseline; gap:7px; min-height:24px; padding:2px 5px; border-radius:4px; }
+.call-label { color:var(--call); text-decoration:none; }
+a.call-label:hover,.machine-link:hover,.targets a:hover { text-decoration:underline; }
+.branch-label { color:var(--branch); font-style:italic; }
+.badge { padding:0 5px; border:1px solid currentColor; border-radius:999px; font-size:10px; opacity:.88; }
+.badge.unique-key-match { color:var(--internal); }
+.badge.multiple-key-matches,.badge.ambiguous { color:var(--ambiguous); }
+.badge.no-key-match { color:var(--external); }
+.badge.branch { color:var(--branch); }
+.badge.exported { color:var(--exported); }
+.count,.source,.targets,.empty,.language { color:var(--muted); font-size:12px; }
+.targets { display:flex; flex-wrap:wrap; gap:5px; }
+.hidden { display:none !important; }
+summary::marker { color:var(--muted); }
+@media (max-width:700px) { header,main { padding-left:12px; padding-right:12px; } .source { display:none; } }
+</style>
+</head>
+<body>
+<header>
+  <h1>calldiff · repository call snapshot</h1>
+  <div class="meta"><span>${escapeHtml(sourceLabel)}</span>${sourceDetails.map((detail) => `<span>${escapeHtml(detail)}</span>`).join("")}<span>${summary.sourceFiles} files</span><span>${summary.definitions} definitions</span><span>${summary.calls} calls</span><span>${summary.branches} branches</span></div>
+  <div class="controls"><input id="search" type="search" placeholder="Filter files, definitions, calls, or branches…"><button id="expand-files">Expand files</button><button id="expand-all">Expand all</button><button id="collapse-all">Collapse all</button></div>
+</header>
+<main>
+  <div class="notice">This HTML file is a human projection. The adjacent <a class="machine-link" href="${escapeHtml(jsonFilename)}">JSON snapshot</a> is the canonical machine record. Key matching is syntactic and limited to selected files that parsed successfully. A no-key-match result does not prove that a call is external.</div>
+  ${diagnostics}
+  <div class="legend"><span style="color:var(--call)">call</span><span style="color:var(--branch)">branch</span><span style="color:var(--internal)">unique key match</span><span style="color:var(--ambiguous)">multiple key matches</span><span style="color:var(--external)">no key match</span></div>
+  <div id="files">${fileSections}</div>
+</main>
+<script>
+const search = document.querySelector('#search');
+const files = [...document.querySelectorAll('.file')];
+const definitions = [...document.querySelectorAll('.definition')];
+search.addEventListener('input', () => {
+  const query = search.value.trim().toLowerCase();
+  if (!query) {
+    files.forEach(file => file.classList.remove('hidden'));
+    definitions.forEach(definition => definition.classList.remove('hidden'));
+    return;
+  }
+  for (const file of files) {
+    let matches = 0;
+    for (const definition of file.querySelectorAll('.definition')) {
+      const match = definition.dataset.search.includes(query);
+      definition.classList.toggle('hidden', !match);
+      if (match) matches += 1;
+    }
+    const fileMatch = file.dataset.file.includes(query);
+    file.classList.toggle('hidden', matches === 0 && !fileMatch);
+    if (matches > 0 || fileMatch) file.querySelector(':scope > details').open = true;
+    if (fileMatch) file.querySelectorAll('.definition').forEach(definition => definition.classList.remove('hidden'));
+  }
+});
+document.querySelector('#expand-files').addEventListener('click', () => files.forEach(file => file.querySelector(':scope > details').open = true));
+document.querySelector('#expand-all').addEventListener('click', () => document.querySelectorAll('details').forEach(detail => detail.open = true));
+document.querySelector('#collapse-all').addEventListener('click', () => document.querySelectorAll('details').forEach(detail => detail.open = false));
+</script>
+</body>
+</html>`;
+}

--- a/src/repository-snapshot-output.ts
+++ b/src/repository-snapshot-output.ts
@@ -1,0 +1,68 @@
+import {
+  lstatSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import type { RepositoryCallSnapshot } from "./repository-snapshot.js";
+import { renderRepositoryCallSnapshotHtml } from "./repository-snapshot-html.js";
+
+export const REPOSITORY_SNAPSHOT_JSON = "calldiff-call-snapshot.json";
+export const REPOSITORY_SNAPSHOT_HTML = "calldiff-call-snapshot.html";
+
+function pathExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/**
+ * Create one immutable bundle containing canonical JSON and derived HTML.
+ * Directory creation is the exclusive claim, so an old snapshot cannot be
+ * replaced. A failed synchronous write removes the incomplete new directory.
+ */
+export function writeRepositoryCallSnapshotBundle(
+  snapshot: RepositoryCallSnapshot,
+  outputDirectory: string,
+): { jsonPath: string; htmlPath: string } {
+  const json = `${JSON.stringify(snapshot, null, 2)}\n`;
+  const html = renderRepositoryCallSnapshotHtml(
+    snapshot,
+    REPOSITORY_SNAPSHOT_JSON,
+  );
+  mkdirSync(dirname(outputDirectory), { recursive: true });
+  if (pathExists(outputDirectory)) {
+    throw new Error(`Snapshot output already exists: ${outputDirectory}`);
+  }
+
+  try {
+    mkdirSync(outputDirectory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(`Snapshot output already exists: ${outputDirectory}`);
+    }
+    throw error;
+  }
+
+  try {
+    writeFileSync(join(outputDirectory, REPOSITORY_SNAPSHOT_JSON), json, {
+      flag: "wx",
+    });
+    writeFileSync(join(outputDirectory, REPOSITORY_SNAPSHOT_HTML), html, {
+      flag: "wx",
+    });
+  } catch (error) {
+    rmSync(outputDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    jsonPath: join(outputDirectory, REPOSITORY_SNAPSHOT_JSON),
+    htmlPath: join(outputDirectory, REPOSITORY_SNAPSHOT_HTML),
+  };
+}

--- a/src/repository-snapshot.ts
+++ b/src/repository-snapshot.ts
@@ -1,0 +1,245 @@
+import { detectLanguage } from "./languages/registry.js";
+import type { LoadedFunctions, ParseDiagnostic } from "./load.js";
+import type { CallStep, FunctionInfo } from "./types.js";
+
+export const REPOSITORY_CALL_SNAPSHOT_SCHEMA =
+  "calldiff-repository-call-snapshot/1" as const;
+
+export type CallKeyMatch =
+  | "unique-key-match"
+  | "multiple-key-matches"
+  | "no-key-match";
+
+export type RepositoryCallStep =
+  | {
+      type: "call";
+      key: string;
+      match: CallKeyMatch;
+      matchingDefinitionIds: string[];
+    }
+  | {
+      type: "branch";
+      key: string;
+      label: string;
+      children: RepositoryCallStep[];
+    };
+
+export interface RepositoryDefinition {
+  id: string;
+  key: string;
+  label: string;
+  file: string;
+  language: string;
+  exported: boolean;
+  span: {
+    /** Zero-based UTF-16 code-unit offsets, matching tree-sitter's JS API. */
+    startIndex: number;
+    endIndex: number;
+    startLine: number;
+    endLine: number;
+  };
+  steps: RepositoryCallStep[];
+}
+
+export type RepositoryCallSource =
+  | {
+      kind: "commit";
+      requestedRef: string;
+      commit: string;
+      pathFilters: string[];
+    }
+  | {
+      kind: "frozen-files";
+      subjectId: string;
+      fileDigests: Array<{ path: string; sha256: string }>;
+    };
+
+export interface RepositoryCallSnapshot {
+  schema: typeof REPOSITORY_CALL_SNAPSHOT_SCHEMA;
+  source: RepositoryCallSource;
+  summary: {
+    sourceFiles: number;
+    definitions: number;
+    exportedDefinitions: number;
+    collidingDefinitionKeys: number;
+    calls: number;
+    uniqueKeyMatchCalls: number;
+    multipleKeyMatchCalls: number;
+    noKeyMatchCalls: number;
+    branches: number;
+    parseWarnings: number;
+  };
+  files: string[];
+  diagnostics: ParseDiagnostic[];
+  definitions: RepositoryDefinition[];
+}
+
+function makeLineOf(source: string): (offset: number) => number {
+  const starts = [0];
+  for (let index = 0; index < source.length; index += 1) {
+    if (source.charCodeAt(index) === 10) starts.push(index + 1);
+  }
+  return (offset) => {
+    let low = 0;
+    let high = starts.length - 1;
+    while (low < high) {
+      const middle = (low + high + 1) >> 1;
+      if (starts[middle]! <= offset) low = middle;
+      else high = middle - 1;
+    }
+    return low + 1;
+  };
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function definitionId(fn: FunctionInfo): string {
+  return `definition:${JSON.stringify([fn.file, fn.start, fn.end, fn.key])}`;
+}
+
+function countSteps(
+  steps: RepositoryCallStep[],
+  visit: (step: RepositoryCallStep) => void,
+): void {
+  for (const step of steps) {
+    visit(step);
+    if (step.type === "branch") countSteps(step.children, visit);
+  }
+}
+
+/**
+ * Build the canonical machine record for one repository call snapshot.
+ * The HTML view is a derived projection of this value.
+ */
+export function buildRepositoryCallSnapshot(
+  loaded: LoadedFunctions,
+  source:
+    | { requestedRef: string; commit: string; pathFilters: string[] }
+    | RepositoryCallSource,
+): RepositoryCallSnapshot {
+  const functions = [...loaded.functions].sort(
+    (left, right) =>
+      compareText(left.file, right.file) ||
+      left.start - right.start ||
+      compareText(left.key, right.key),
+  );
+  const lineOfByFile = new Map(
+    [...loaded.sources].map(([file, text]) => [file, makeLineOf(text)]),
+  );
+
+  const definitions: RepositoryDefinition[] = functions.map((fn) => {
+    const lineOf = lineOfByFile.get(fn.file) ?? (() => 1);
+    return {
+      id: definitionId(fn),
+      key: fn.key,
+      label: fn.label,
+      file: fn.file,
+      language: detectLanguage(fn.file)?.id ?? "unknown",
+      exported: fn.exported,
+      span: {
+        startIndex: fn.start,
+        endIndex: fn.end,
+        startLine: lineOf(fn.start),
+        endLine: lineOf(fn.end),
+      },
+      steps: [],
+    };
+  });
+
+  const uniqueIds = new Set(definitions.map((definition) => definition.id));
+  if (uniqueIds.size !== definitions.length) {
+    throw new Error("Duplicate repository definition coordinates");
+  }
+
+  const definitionsByKey = new Map<string, RepositoryDefinition[]>();
+  for (const definition of definitions) {
+    definitionsByKey.set(definition.key, [
+      ...(definitionsByKey.get(definition.key) ?? []),
+      definition,
+    ]);
+    if (definition.key.endsWith(".constructor")) {
+      const className = definition.key.slice(0, -".constructor".length);
+      const alias = `new ${className}`;
+      definitionsByKey.set(alias, [
+        ...(definitionsByKey.get(alias) ?? []),
+        definition,
+      ]);
+    }
+  }
+
+  const convertSteps = (steps: CallStep[]): RepositoryCallStep[] =>
+    steps.map((step) => {
+      if (step.type === "branch") {
+        return {
+          type: "branch",
+          key: step.key,
+          label: step.label,
+          children: convertSteps(step.children),
+        };
+      }
+      const targets = definitionsByKey.get(step.key) ?? [];
+      return {
+        type: "call",
+        key: step.key,
+        match:
+          targets.length === 0
+            ? "no-key-match"
+            : targets.length === 1
+              ? "unique-key-match"
+              : "multiple-key-matches",
+        matchingDefinitionIds: targets.map((target) => target.id),
+      };
+    });
+
+  for (let index = 0; index < definitions.length; index += 1) {
+    definitions[index]!.steps = convertSteps(functions[index]!.steps);
+  }
+
+  let calls = 0;
+  let uniqueKeyMatchCalls = 0;
+  let multipleKeyMatchCalls = 0;
+  let noKeyMatchCalls = 0;
+  let branches = 0;
+  for (const definition of definitions) {
+    countSteps(definition.steps, (step) => {
+      if (step.type === "branch") {
+        branches += 1;
+        return;
+      }
+      calls += 1;
+      if (step.match === "unique-key-match") uniqueKeyMatchCalls += 1;
+      if (step.match === "multiple-key-matches") multipleKeyMatchCalls += 1;
+      if (step.match === "no-key-match") noKeyMatchCalls += 1;
+    });
+  }
+
+  const collidingDefinitionKeys = [...definitionsByKey.entries()].filter(
+    ([key, matches]) => !key.startsWith("new ") && matches.length > 1,
+  ).length;
+
+  const normalizedSource: RepositoryCallSource =
+    "kind" in source ? source : { kind: "commit", ...source };
+
+  return {
+    schema: REPOSITORY_CALL_SNAPSHOT_SCHEMA,
+    source: normalizedSource,
+    summary: {
+      sourceFiles: loaded.files.length,
+      definitions: definitions.length,
+      exportedDefinitions: definitions.filter((definition) => definition.exported)
+        .length,
+      collidingDefinitionKeys,
+      calls,
+      uniqueKeyMatchCalls,
+      multipleKeyMatchCalls,
+      noKeyMatchCalls,
+      branches,
+      parseWarnings: loaded.diagnostics.length,
+    },
+    files: loaded.files,
+    diagnostics: loaded.diagnostics,
+    definitions,
+  };
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,42 +1,79 @@
+import { relative, resolve } from "node:path";
 import { parseArgs, printHelp } from "./args.js";
-import { buildIndex, extractFunctions } from "./extract.js";
+import { buildIndex } from "./extract.js";
 import {
-  assertGitRepo,
   describeSnapshot,
-  listTsFiles,
-  readSnapshotFile,
+  normalizePathFilters,
+  repositoryRoot,
+  resolveCommit,
   resolveSnapshots,
   verifyCommit,
 } from "./git.js";
 import { diffEntry, inferEntries } from "./infer.js";
+import { loadFunctions } from "./load.js";
 import { renderDiff } from "./render.js";
-import type { Snapshot } from "./types.js";
+import { buildRepositoryCallSnapshot } from "./repository-snapshot.js";
+import { writeRepositoryCallSnapshotBundle } from "./repository-snapshot-output.js";
 import type { FunctionIndex } from "./extract.js";
+import type { Snapshot, SnapshotCliOptions } from "./types.js";
 
 function loadIndex(
   cwd: string,
   snapshot: Snapshot,
   pathFilters: string[],
 ): FunctionIndex {
-  const files = listTsFiles(cwd, snapshot, pathFilters);
-  const all = [];
-  for (const file of files) {
-    const source = readSnapshotFile(cwd, snapshot, file);
-    if (source === null) continue;
-    try {
-      all.push(...extractFunctions(file, source));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`warn: failed to parse ${file} @ ${snapshot.ref}: ${message}`);
-    }
+  const loaded = loadFunctions(cwd, snapshot, pathFilters);
+  for (const diagnostic of loaded.diagnostics) {
+    console.error(
+      `warn: failed to parse ${diagnostic.file} @ ${snapshot.ref}: ${diagnostic.message}`,
+    );
   }
-  return buildIndex(all);
+  return buildIndex(loaded.functions);
 }
 
-export async function run(argv: string[]): Promise<number> {
+function runSnapshot(options: SnapshotCliOptions, repoRoot: string): number {
+  if (!options.output) {
+    console.error("Missing required snapshot option: --output <directory>");
+    return 2;
+  }
+
+  const commit = resolveCommit(repoRoot, options.ref);
+  const pathFilters = normalizePathFilters(options.paths);
+  const loaded = loadFunctions(
+    repoRoot,
+    { kind: "commit", ref: commit },
+    pathFilters,
+    { failOnReadError: true },
+  );
+  const snapshot = buildRepositoryCallSnapshot(loaded, {
+    requestedRef: options.ref,
+    commit,
+    pathFilters,
+  });
+  const outputDirectory = resolve(options.cwd, options.output);
+  const written = writeRepositoryCallSnapshotBundle(snapshot, outputDirectory);
+  const summary = snapshot.summary;
+
+  console.log(
+    `calldiff snapshot ${commit.slice(0, 12)}: ${summary.definitions} definitions, ${summary.calls} calls, ${summary.branches} branches`,
+  );
+  console.log(`machine: ${relative(options.cwd, written.jsonPath)}`);
+  console.log(`human:   ${relative(options.cwd, written.htmlPath)}`);
+  if (summary.parseWarnings > 0) {
+    console.error(
+      `warn: ${summary.parseWarnings} files failed to parse; inspect diagnostics in the JSON snapshot`,
+    );
+  }
+  return 0;
+}
+
+export async function run(
+  argv: string[],
+  invocationCwd = process.cwd(),
+): Promise<number> {
   let options;
   try {
-    options = parseArgs(argv);
+    options = parseArgs(argv, invocationCwd);
   } catch (error) {
     console.error(error instanceof Error ? error.message : error);
     printHelp();
@@ -48,8 +85,16 @@ export async function run(argv: string[]): Promise<number> {
     return 0;
   }
 
-  const cwd = options.cwd;
-  assertGitRepo(cwd);
+  const cwd = repositoryRoot(options.cwd);
+
+  if (options.command === "snapshot") {
+    try {
+      return runSnapshot(options, cwd);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      return 1;
+    }
+  }
 
   const { from, to } = resolveSnapshots(options.from, options.to);
   if (from.kind === "commit") verifyCommit(cwd, from.ref);

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,8 @@ export interface Snapshot {
   ref: string;
 }
 
-export interface CliOptions {
+export interface DiffCliOptions {
+  command: "diff";
   from?: string;
   to?: string;
   entries: string[];
@@ -63,3 +64,14 @@ export interface CliOptions {
   maxDepth: number;
   help: boolean;
 }
+
+export interface SnapshotCliOptions {
+  command: "snapshot";
+  ref: string;
+  output?: string;
+  paths: string[];
+  cwd: string;
+  help: boolean;
+}
+
+export type CliOptions = DiffCliOptions | SnapshotCliOptions;

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { parseArgs } from "../src/args.js";
+
+describe("parseArgs", () => {
+  test("keeps the default diff command", () => {
+    expect(parseArgs(["main", "feature"], "/repo")).toMatchObject({
+      command: "diff",
+      from: "main",
+      to: "feature",
+      cwd: "/repo",
+    });
+  });
+
+  test("parses a repository snapshot bundle", () => {
+    expect(
+      parseArgs(
+        ["--snapshot", "main", "--output", ".calldiff", "--", "src", "lib"],
+        "/repo",
+      ),
+    ).toEqual({
+      command: "snapshot",
+      ref: "main",
+      output: ".calldiff",
+      paths: ["src", "lib"],
+      cwd: "/repo",
+      help: false,
+    });
+  });
+
+  test("keeps snapshot as a valid legacy diff ref", () => {
+    expect(parseArgs(["snapshot"], "/repo")).toMatchObject({
+      command: "diff",
+      from: "snapshot",
+    });
+  });
+
+  test("allows snapshot-specific help without a ref", () => {
+    expect(parseArgs(["--snapshot", "--help"], "/repo")).toMatchObject({
+      command: "snapshot",
+      ref: "HEAD",
+      help: true,
+    });
+  });
+
+  test("rejects positional arguments in snapshot mode", () => {
+    expect(() =>
+      parseArgs(["--snapshot", "main", "feature", "-o", "out"], "/repo"),
+    ).toThrow("Unexpected snapshot argument: feature");
+  });
+});

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import {
+  listSourceFiles,
+  normalizePathFilters,
+  readSnapshotFile,
+  repositoryRoot,
+  resolveCommit,
+} from "../src/git.js";
+
+test("path filters use repository-relative boundaries", () => {
+  const directory = mkdtempSync(join(tmpdir(), "calldiff-paths-"));
+  try {
+    mkdirSync(join(directory, "nested"));
+    writeFileSync(join(directory, "foo.ts"), "function root() {}\n");
+    writeFileSync(join(directory, "nested", "foo.ts"), "function nested() {}\n");
+    writeFileSync(
+      join(directory, "nested", "otherfoo.ts"),
+      "function other() {}\n",
+    );
+    const worktree = { kind: "worktree", ref: "WORKTREE" } as const;
+
+    expect(listSourceFiles(directory, worktree, ["foo.ts"])).toEqual([
+      "foo.ts",
+    ]);
+    expect(listSourceFiles(directory, worktree, ["nested"])).toEqual([
+      "nested/foo.ts",
+      "nested/otherfoo.ts",
+    ]);
+    expect(listSourceFiles(directory, worktree, ["."])).toEqual([
+      "foo.ts",
+      "nested/foo.ts",
+      "nested/otherfoo.ts",
+    ]);
+    expect(listSourceFiles(directory, worktree, ["nested\\foo.ts"])).toEqual([
+      "nested/foo.ts",
+    ]);
+    expect(normalizePathFilters(["src/", "./src", "test", "src"])).toEqual([
+      "src",
+      "test",
+    ]);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("commit snapshots keep root paths and ignore replacement refs", () => {
+  const directory = mkdtempSync(join(tmpdir(), "calldiff-git-root-"));
+  const fixtureEmail = "calldiff-test" + "@" + "example.invalid";
+  try {
+    execFileSync("git", ["init", "-q"], { cwd: directory });
+    mkdirSync(join(directory, "src"));
+    writeFileSync(join(directory, "src", "app.ts"), "function app() {}\n");
+    writeFileSync(join(directory, "src", "é.ts"), "function unicode() {}\n");
+    writeFileSync(
+      join(directory, "src", "line\nbreak.ts"),
+      "function newline() {}\n",
+    );
+    execFileSync("git", ["add", "."], { cwd: directory });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=calldiff-test",
+        "-c",
+        `user.email=${fixtureEmail}`,
+        "commit",
+        "-qm",
+        "fixture",
+      ],
+      { cwd: directory },
+    );
+    const originalCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: directory,
+      encoding: "utf8",
+    }).trim();
+    writeFileSync(
+      join(directory, "src", "app.ts"),
+      "function replacement() {}\n",
+    );
+    execFileSync("git", ["add", "."], { cwd: directory });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=calldiff-test",
+        "-c",
+        `user.email=${fixtureEmail}`,
+        "commit",
+        "-qm",
+        "replacement fixture",
+      ],
+      { cwd: directory },
+    );
+    const replacementCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: directory,
+      encoding: "utf8",
+    }).trim();
+    execFileSync("git", ["replace", originalCommit, replacementCommit], {
+      cwd: directory,
+    });
+
+    const subdirectory = join(directory, "src");
+    const commit = resolveCommit(subdirectory, originalCommit);
+    const snapshot = { kind: "commit", ref: commit } as const;
+
+    expect(commit).toBe(originalCommit);
+    expect(repositoryRoot(subdirectory)).toBe(realpathSync(directory));
+    expect(listSourceFiles(subdirectory, snapshot)).toEqual([
+      "src/app.ts",
+      "src/line\nbreak.ts",
+      "src/é.ts",
+    ]);
+    expect(readSnapshotFile(subdirectory, snapshot, "src/app.ts")).toBe(
+      "function app() {}\n",
+    );
+    expect(readSnapshotFile(subdirectory, snapshot, "src/é.ts")).toBe(
+      "function unicode() {}\n",
+    );
+    expect(
+      readSnapshotFile(subdirectory, snapshot, "src/line\nbreak.ts"),
+    ).toBe("function newline() {}\n");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/repository-snapshot.test.ts
+++ b/test/repository-snapshot.test.ts
@@ -1,0 +1,248 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { extractFunctions } from "../src/extract.js";
+import type { LoadedFunctions } from "../src/load.js";
+import {
+  analyzeRepositoryFiles,
+  diffRepositoryCallSnapshots,
+  projectRepositoryCallSnapshot,
+  REPOSITORY_CALL_DELTA_SCHEMA,
+  REPOSITORY_CALL_PROJECTION_SCHEMA,
+} from "../src/repository-analysis.js";
+import {
+  buildRepositoryCallSnapshot,
+  REPOSITORY_CALL_SNAPSHOT_SCHEMA,
+} from "../src/repository-snapshot.js";
+import { renderRepositoryCallSnapshotHtml } from "../src/repository-snapshot-html.js";
+import {
+  REPOSITORY_SNAPSHOT_HTML,
+  REPOSITORY_SNAPSHOT_JSON,
+  writeRepositoryCallSnapshotBundle,
+} from "../src/repository-snapshot-output.js";
+
+const firstSource = `export function start(flag: boolean) {
+  helper();
+  shared();
+  missing();
+  if (flag) {
+    work();
+  }
+}
+function helper() {}
+function shared() {}
+`;
+
+const secondSource = `function shared() {}
+function work() {}
+`;
+
+function fixture(): LoadedFunctions {
+  return {
+    files: ["src/first.ts", "src/second.ts"],
+    functions: [
+      ...extractFunctions("src/first.ts", firstSource),
+      ...extractFunctions("src/second.ts", secondSource),
+    ],
+    sources: new Map([
+      ["src/first.ts", firstSource],
+      ["src/second.ts", secondSource],
+    ]),
+    diagnostics: [],
+  };
+}
+
+describe("repository call snapshot", () => {
+  test("keeps all definitions and reports syntactic key matches", () => {
+    const snapshot = buildRepositoryCallSnapshot(fixture(), {
+      requestedRef: "HEAD",
+      commit: "a".repeat(40),
+      pathFilters: ["src"],
+    });
+
+    expect(snapshot.schema).toBe(REPOSITORY_CALL_SNAPSHOT_SCHEMA);
+    expect(new Set(snapshot.definitions.map((definition) => definition.id)).size)
+      .toBe(snapshot.definitions.length);
+    expect(snapshot.definitions[0]!.id).toMatch(/^definition:\[/);
+    expect(snapshot.summary).toMatchObject({
+      sourceFiles: 2,
+      definitions: 5,
+      collidingDefinitionKeys: 1,
+      calls: 4,
+      uniqueKeyMatchCalls: 2,
+      multipleKeyMatchCalls: 1,
+      noKeyMatchCalls: 1,
+      branches: 1,
+      parseWarnings: 0,
+    });
+
+    const start = snapshot.definitions.find(
+      (definition) => definition.key === "start",
+    );
+    expect(start).toBeDefined();
+    expect(start).toMatchObject({
+      file: "src/first.ts",
+      language: "typescript",
+      exported: true,
+      span: { startLine: 1, endLine: 8 },
+    });
+
+    const calls = start!.steps.flatMap((step) =>
+      step.type === "call"
+        ? [step]
+        : step.children.filter((child) => child.type === "call"),
+    );
+    expect(calls.map(({ key, match, matchingDefinitionIds }) => ({
+      key,
+      match,
+      targets: matchingDefinitionIds.length,
+    }))).toEqual([
+      { key: "helper", match: "unique-key-match", targets: 1 },
+      { key: "shared", match: "multiple-key-matches", targets: 2 },
+      { key: "missing", match: "no-key-match", targets: 0 },
+      { key: "work", match: "unique-key-match", targets: 1 },
+    ]);
+  });
+
+  test("uses deterministic ordering and UTF-16 source coordinates", () => {
+    const unicodeSource = '// 😀\nfunction unicodeName() { "😀"; }\n';
+    const sources = new Map([
+      ["src/é.ts", unicodeSource],
+      ["src/z.ts", "function zed() {}\n"],
+      ["src/A.ts", "function alpha() {}\n"],
+    ]);
+    const snapshot = buildRepositoryCallSnapshot(
+      {
+        files: [...sources.keys()],
+        functions: [...sources].flatMap(([file, source]) =>
+          extractFunctions(file, source),
+        ),
+        sources,
+        diagnostics: [],
+      },
+      {
+        requestedRef: "HEAD",
+        commit: "d".repeat(40),
+        pathFilters: ["src"],
+      },
+    );
+
+    expect(snapshot.definitions.map((definition) => definition.file)).toEqual([
+      "src/A.ts",
+      "src/z.ts",
+      "src/é.ts",
+    ]);
+    const unicode = snapshot.definitions.find(
+      (definition) => definition.key === "unicodeName",
+    );
+    expect(unicode?.span).toMatchObject({
+      startIndex: unicodeSource.indexOf("function"),
+      endIndex: unicodeSource.indexOf("\n", unicodeSource.indexOf("function")),
+      startLine: 2,
+      endLine: 2,
+    });
+  });
+
+  test("analyzes frozen files, projects neighborhoods, and diffs snapshots", () => {
+    const before = analyzeRepositoryFiles(
+      [
+        { path: "src/entry.ts", content: "export function entry() { helper(); }\n" },
+        { path: "src/helper.ts", content: "function helper() {}\n" },
+        { path: "src/unrelated.ts", content: "function unrelated() {}\n" },
+        { path: "README.md", content: "not parsed\n" },
+      ],
+      "subject/before",
+    );
+    const after = analyzeRepositoryFiles(
+      [
+        { path: "src/entry.ts", content: "export function entry() { replacement(); }\n" },
+        { path: "src/replacement.ts", content: "function replacement() {}\n" },
+      ],
+      "subject/after",
+    );
+
+    expect(before.source).toMatchObject({
+      kind: "frozen-files",
+      subjectId: "subject/before",
+    });
+    expect(before.files).toEqual([
+      "src/entry.ts",
+      "src/helper.ts",
+      "src/unrelated.ts",
+    ]);
+
+    const projection = projectRepositoryCallSnapshot(before, ["src/entry.ts"]);
+    expect(projection.schema).toBe(REPOSITORY_CALL_PROJECTION_SCHEMA);
+    expect(projection.includedFiles).toEqual(["src/entry.ts", "src/helper.ts"]);
+    expect(projection.omittedDefinitions).toBe(1);
+
+    const delta = diffRepositoryCallSnapshots(before, after);
+    expect(delta.schema).toBe(REPOSITORY_CALL_DELTA_SCHEMA);
+    expect(delta.summary).toEqual({
+      addedDefinitions: 1,
+      removedDefinitions: 2,
+      changedDefinitions: 1,
+      unchangedDefinitions: 0,
+    });
+    expect(delta.changes.find((change) => change.matchId === "src/entry.ts:entry#1"))
+      .toMatchObject({ change: "changed" });
+  });
+
+  test("renders a concise human projection linked to canonical JSON", () => {
+    const snapshot = buildRepositoryCallSnapshot(fixture(), {
+      requestedRef: "main",
+      commit: "b".repeat(40),
+      pathFilters: [],
+    });
+    snapshot.definitions[0]!.label = '<script>alert("x")</script>';
+
+    const html = renderRepositoryCallSnapshotHtml(
+      snapshot,
+      "calldiff-call-snapshot.json",
+    );
+
+    expect(html).toContain("repository call snapshot");
+    expect(html).toContain('href="calldiff-call-snapshot.json"');
+    expect(html).toContain("unique key match");
+    expect(html).toContain("multiple key matches");
+    expect(html).toContain("no key match");
+    expect(html).toContain("requested main");
+    expect(html).toContain("scope all supported files");
+    expect(html).toContain("does not prove that a call is external");
+    expect(html).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+    expect(html).not.toContain('<script>alert("x")</script>');
+  });
+
+  test("writes the canonical record and derived projection together", () => {
+    const snapshot = buildRepositoryCallSnapshot(fixture(), {
+      requestedRef: "HEAD",
+      commit: "c".repeat(40),
+      pathFilters: ["src"],
+    });
+    const parent = mkdtempSync(join(tmpdir(), "calldiff-snapshot-test-"));
+    const directory = join(parent, "snapshot");
+
+    try {
+      const written = writeRepositoryCallSnapshotBundle(snapshot, directory);
+      expect(JSON.parse(readFileSync(written.jsonPath, "utf8"))).toEqual(
+        snapshot,
+      );
+      expect(readFileSync(written.htmlPath, "utf8")).toContain(
+        `href="${REPOSITORY_SNAPSHOT_JSON}"`,
+      );
+      expect(written.jsonPath).toBe(join(directory, REPOSITORY_SNAPSHOT_JSON));
+      expect(written.htmlPath).toBe(join(directory, REPOSITORY_SNAPSHOT_HTML));
+      expect(() =>
+        writeRepositoryCallSnapshotBundle(snapshot, directory),
+      ).toThrow("Snapshot output already exists");
+      const emptyDirectory = join(parent, "empty");
+      mkdirSync(emptyDirectory);
+      expect(() =>
+        writeRepositoryCallSnapshotBundle(snapshot, emptyDirectory),
+      ).toThrow("Snapshot output already exists");
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/snapshot-cli.test.ts
+++ b/test/snapshot-cli.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+import { REPOSITORY_SNAPSHOT_JSON } from "../src/repository-snapshot-output.js";
+import { run } from "../src/run.js";
+
+const git = (cwd: string, args: string[]): string =>
+  execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+test("snapshot CLI freezes a root-scoped commit from a subdirectory", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "calldiff-cli-"));
+  const fixtureEmail = "calldiff-test" + "@" + "example.invalid";
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  try {
+    git(directory, ["init", "-q"]);
+    mkdirSync(join(directory, "src"));
+    writeFileSync(
+      join(directory, "src", "é.ts"),
+      "export function entry() { helper(); }\nfunction helper() {}\n",
+    );
+    git(directory, ["add", "."]);
+    git(directory, [
+      "-c",
+      "user.name=calldiff-test",
+      "-c",
+      `user.email=${fixtureEmail}`,
+      "commit",
+      "-qm",
+      "fixture",
+    ]);
+    const commit = git(directory, ["rev-parse", "HEAD"]);
+    git(directory, ["branch", "snapshot"]);
+    const subdirectory = join(directory, "src");
+
+    expect(
+      await run(
+        ["--snapshot", "HEAD", "--output", "evidence", "--", "."],
+        subdirectory,
+      ),
+    ).toBe(0);
+    const jsonPath = join(subdirectory, "evidence", REPOSITORY_SNAPSHOT_JSON);
+    const artifact = JSON.parse(readFileSync(jsonPath, "utf8"));
+    expect(artifact.source).toEqual({
+      kind: "commit",
+      requestedRef: "HEAD",
+      commit,
+      pathFilters: [],
+    });
+    expect(artifact.files).toEqual(["src/é.ts"]);
+    expect(artifact.definitions.map((definition: { key: string }) => definition.key))
+      .toEqual(["entry", "helper"]);
+
+    expect(await run(["snapshot"], directory)).toBe(0);
+    expect(await run(["HEAD", "snapshot"], directory)).toBe(0);
+    expect(
+      await run(
+        ["--snapshot", "HEAD", "--output", "evidence", "--", "."],
+        subdirectory,
+      ),
+    ).toBe(1);
+    expect(JSON.parse(readFileSync(jsonPath, "utf8")).source.commit).toBe(
+      commit,
+    );
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("Snapshot output already exists"),
+    );
+  } finally {
+    log.mockRestore();
+    error.mockRestore();
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
+    // Grammar packages share one cache and must not install concurrently.
+    maxWorkers: 1,
     // Keep on-demand grammars out of the repo; reuse across test runs in this env.
     env: {
       CALLDIFF_GRAMMAR_CACHE: join(tmpdir(), "calldiff-grammar-cache"),


### PR DESCRIPTION
## Why

Calldiff is good at explaining how call flow changed between two revisions. Some review and exploration tasks also need the full call structure of one revision, without first choosing an entrypoint or manufacturing a diff.

This adds that second workflow while keeping the existing diff behavior unchanged.

## What this adds

Run:

```bash
calldiff --snapshot HEAD --output .calldiff/head -- src
```

Calldiff writes two views of the same evidence:

- `calldiff-call-snapshot.json` is the canonical, structured record for agents, scripts, `jq`, and editors.
- `calldiff-call-snapshot.html` is a derived, searchable, collapsible, syntax-colored view for people.

The JSON records every extracted definition and its ordered calls and branches. Calls report whether their key has one, several, or no matching definitions in the selected, successfully parsed files. This is intentionally syntactic evidence, not type resolution.

The output directory must be new. This prevents a later run from silently overwriting an earlier review artifact.

## Library use

The package now also exports APIs for integrations that already own the source bytes:

- `analyzeRepositoryFiles` analyzes frozen `{ path, content }` records.
- `diffRepositoryCallSnapshots` compares two retained snapshots without parsing again.
- `projectRepositoryCallSnapshot` derives a smaller view with selected definitions, direct matches, callers, diagnostics, and an omitted count.

This keeps the full JSON snapshot as the source of truth while allowing task-specific projections.

## Reliability work

The snapshot path uses repository-root-relative paths, NUL-safe Git filename handling, strict immutable commit reads, and disabled Git replacement refs. Definition IDs use unambiguous tuple encoding. Path filters normalize root, relative, and Windows-style input.

## Verification

- `npm test` — 190 tests passed across 27 files
- `npm run build`
- Browser check of search, collapse, JSON linkage, and match labels
- Public-history and publication-range privacy checks