### PR TITLE
Add `calldiff show` for viewing call trees without diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ calldiff main feature -e PiService.createAgentSession -e boot
 
 # limit to paths
 calldiff main feature -- src/lib
+
+# view a call tree (no diff) — requires --entry
+calldiff show -e createAgentSession
+calldiff show HEAD -e PiService.createAgentSession
+calldiff show main -e boot --max-depth 8 -- src/lib
 ```
 
 ### Semantics (git-diff shaped)
@@ -60,6 +65,15 @@ calldiff main feature -- src/lib
 
 `-` lines were present in **from** and gone in **to**.  
 `+` lines are new in **to**.
+
+### View (no diff)
+
+| Invocation | Tree from |
+|---|---|
+| `calldiff show -e <name>` | working tree |
+| `calldiff show <ref> -e <name>` | that commit/ref |
+
+Prints a plain ASCII call tree (no `+/−` markers). `--entry` / `-e` is required.
 
 ### Labels
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -15,9 +15,15 @@ function takeValue(argv: string[], i: number, flag: string): [string, number] {
  *   calldiff <from> <to>
  *   calldiff --from <ref> --to <ref>
  *   calldiff ... --entry Name [--entry Class.method] -- [paths...]
+ *
+ * View mode:
+ *   calldiff show
+ *   calldiff show <ref>
+ *   calldiff show [<ref>] --entry Name ...
  */
 export function parseArgs(argv: string[], cwd = process.cwd()): CliOptions {
   const options: CliOptions = {
+    mode: "diff",
     entries: [],
     paths: [],
     cwd,
@@ -82,6 +88,31 @@ export function parseArgs(argv: string[], cwd = process.cwd()): CliOptions {
     i += 1;
   }
 
+  if (positionals[0] === "show") {
+    options.mode = "show";
+    positionals.shift();
+
+    if (options.from !== undefined || options.to !== undefined) {
+      throw new Error("calldiff show does not accept --from / --to");
+    }
+
+    if (positionals.length > 1) {
+      throw new Error(
+        `Too many arguments for show: expected at most one ref, got ${positionals.length}`,
+      );
+    }
+
+    if (positionals[0]) {
+      options.from = positionals[0];
+    }
+
+    if (!options.help && options.entries.length === 0) {
+      throw new Error("calldiff show requires --entry / -e");
+    }
+
+    return options;
+  }
+
   // Positional refs fill in from/to when flags weren't set (git-diff style).
   if (positionals.length > 2) {
     throw new Error(
@@ -113,17 +144,24 @@ Usage:
   calldiff <from> <to>
   calldiff --from <ref> --to <ref>
   calldiff [refs] --entry <name> [--entry <Class.method>] [-- paths...]
+  calldiff show [<ref>] --entry <name> [--entry <Class.method>] [-- paths...]
 
 Semantics (like git diff):
   (no refs)     from=HEAD, to=working tree
   <from>        from=<from>, to=working tree
   <from> <to>   compare those two trees
 
+View (no diff):
+  show          call tree(s) from working tree
+  show <ref>    call tree(s) from that commit/ref
+                requires -e/--entry
+
 Options:
-  --from <ref>       Left / "before" tree
-  --to <ref>         Right / "after" tree
+  --from <ref>       Left / "before" tree (diff mode)
+  --to <ref>         Right / "after" tree (diff mode)
   -e, --entry <name> Entrypoint(s): functionName or ClassName.method
-                     If omitted, infer exported functions whose call trees changed
+                     Diff: if omitted, infer exported functions whose call trees changed
+                     Show: required
   --max-depth <n>    Max call-tree depth (default: 12)
   -h, --help         Show help
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -36,6 +36,14 @@ export function resolveSnapshots(
   return { from: left, to: right };
 }
 
+/** Single snapshot for `calldiff show` — no ref → working tree. */
+export function resolveSnapshot(ref: string | undefined): Snapshot {
+  if (ref === undefined) {
+    return { kind: "worktree", ref: "WORKTREE" };
+  }
+  return { kind: "commit", ref };
+}
+
 export function verifyCommit(cwd: string, ref: string): void {
   try {
     git(cwd, ["rev-parse", "--verify", `${ref}^{commit}`]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ export { parseArgs, printHelp } from "./args.js";
 export { buildCallTree, resolveEntry } from "./calltree.js";
 export { diffTrees, treeHasChanges } from "./diff.js";
 export { buildIndex, extractFunctions } from "./extract.js";
-export { renderDiff } from "./render.js";
+export { renderDiff, renderTree } from "./render.js";
 export { run } from "./run.js";
 export type * from "./types.js";

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import type { DiffNode, DiffStatus } from "./types.js";
+import type { CallNode, DiffNode, DiffStatus } from "./types.js";
 
 function paint(status: DiffStatus, text: string): string {
   switch (status) {
@@ -28,12 +28,17 @@ export interface RenderOptions {
   color?: boolean;
 }
 
-/**
- * Render a callstack diff as an ASCII tree with +/- markers.
- */
-export function renderDiff(
-  root: DiffNode,
-  options: RenderOptions = {},
+type TreeLike = {
+  label: string;
+  kind?: CallNode["kind"];
+  children: TreeLike[];
+  status?: DiffStatus;
+};
+
+function renderAsciiTree(
+  root: TreeLike,
+  options: RenderOptions,
+  withStatus: boolean,
 ): string {
   const useColor = options.color !== false;
 
@@ -57,13 +62,18 @@ export function renderDiff(
   const lines: string[] = [];
 
   const walk = (
-    node: DiffNode,
+    node: TreeLike,
     indent: string,
     isLast: boolean,
     isRoot: boolean,
   ) => {
     const branch = isRoot ? "" : isLast ? "└─ " : "├─ ";
-    const line = `${statusPrefix(node.status)} ${indent}${branch}${paintStatus(node.status, node.label)}`;
+    const label = withStatus
+      ? paintStatus(node.status ?? "same", node.label)
+      : node.label;
+    const line = withStatus
+      ? `${statusPrefix(node.status ?? "same")} ${indent}${branch}${label}`
+      : `${indent}${branch}${label}`;
     lines.push(line);
 
     // Conditional arms omit the continuing │ rail — they are alternate paths,
@@ -84,4 +94,24 @@ export function renderDiff(
 
   walk(root, "", true, true);
   return lines.join("\n");
+}
+
+/**
+ * Render a callstack diff as an ASCII tree with +/- markers.
+ */
+export function renderDiff(
+  root: DiffNode,
+  options: RenderOptions = {},
+): string {
+  return renderAsciiTree(root, options, true);
+}
+
+/**
+ * Render a single call tree as an ASCII tree (no +/- markers).
+ */
+export function renderTree(
+  root: CallNode,
+  options: RenderOptions = {},
+): string {
+  return renderAsciiTree(root, options, false);
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,15 +1,17 @@
 import { parseArgs, printHelp } from "./args.js";
+import { buildCallTree, resolveEntry } from "./calltree.js";
 import { buildIndex, extractFunctions } from "./extract.js";
 import {
   assertGitRepo,
   describeSnapshot,
   listTsFiles,
   readSnapshotFile,
+  resolveSnapshot,
   resolveSnapshots,
   verifyCommit,
 } from "./git.js";
 import { diffEntry, inferEntries } from "./infer.js";
-import { renderDiff } from "./render.js";
+import { renderDiff, renderTree } from "./render.js";
 import type { Snapshot } from "./types.js";
 import type { FunctionIndex } from "./extract.js";
 
@@ -33,24 +35,52 @@ function loadIndex(
   return buildIndex(all);
 }
 
-export async function run(argv: string[]): Promise<number> {
-  let options;
+function resolveShowEntries(index: FunctionIndex, explicit: string[]): string[] {
+  const resolved: string[] = [];
+  for (const entry of explicit) {
+    const key = resolveEntry(entry, index);
+    if (!key) {
+      throw new Error(`Entrypoint not found: ${entry}`);
+    }
+    if (!resolved.includes(key)) resolved.push(key);
+  }
+  return resolved;
+}
+
+async function runShow(
+  cwd: string,
+  options: ReturnType<typeof parseArgs>,
+): Promise<number> {
+  const snapshot = resolveSnapshot(options.from);
+  if (snapshot.kind === "commit") verifyCommit(cwd, snapshot.ref);
+
+  const index = loadIndex(cwd, snapshot, options.paths);
+
+  let entries: string[];
   try {
-    options = parseArgs(argv);
+    entries = resolveShowEntries(index, options.entries);
   } catch (error) {
     console.error(error instanceof Error ? error.message : error);
-    printHelp();
-    return 2;
+    return 1;
   }
 
-  if (options.help) {
-    printHelp();
-    return 0;
+  console.log(`calldiff show ${describeSnapshot(snapshot)}\n`);
+
+  let printed = 0;
+  for (const entry of entries) {
+    const tree = buildCallTree(entry, index, options.maxDepth);
+    if (printed > 0) console.log("");
+    console.log(renderTree(tree));
+    printed += 1;
   }
 
-  const cwd = options.cwd;
-  assertGitRepo(cwd);
+  return 0;
+}
 
+async function runDiff(
+  cwd: string,
+  options: ReturnType<typeof parseArgs>,
+): Promise<number> {
   const { from, to } = resolveSnapshots(options.from, options.to);
   if (from.kind === "commit") verifyCommit(cwd, from.ref);
   if (to.kind === "commit") verifyCommit(cwd, to.ref);
@@ -91,4 +121,29 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   return 0;
+}
+
+export async function run(argv: string[]): Promise<number> {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    printHelp();
+    return 2;
+  }
+
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  const cwd = options.cwd;
+  assertGitRepo(cwd);
+
+  if (options.mode === "show") {
+    return runShow(cwd, options);
+  }
+
+  return runDiff(cwd, options);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,10 @@ export interface Snapshot {
   ref: string;
 }
 
+export type CliMode = "diff" | "show";
+
 export interface CliOptions {
+  mode: CliMode;
   from?: string;
   to?: string;
   entries: string[];

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { parseArgs } from "../src/args.js";
+
+describe("parseArgs show mode", () => {
+  test("show with entry defaults to working tree", () => {
+    const opts = parseArgs(["show", "-e", "boot"], "/repo");
+    expect(opts.mode).toBe("show");
+    expect(opts.from).toBeUndefined();
+    expect(opts.to).toBeUndefined();
+    expect(opts.entries).toEqual(["boot"]);
+    expect(opts.cwd).toBe("/repo");
+    expect(opts.maxDepth).toBe(12);
+  });
+
+  test("show with ref and multiple entries", () => {
+    const opts = parseArgs(
+      ["show", "abc123", "-e", "Foo.bar", "--entry", "baz"],
+      "/repo",
+    );
+    expect(opts.mode).toBe("show");
+    expect(opts.from).toBe("abc123");
+    expect(opts.entries).toEqual(["Foo.bar", "baz"]);
+  });
+
+  test("show accepts --max-depth and path filters", () => {
+    const opts = parseArgs(
+      ["show", "HEAD", "-e", "main", "--max-depth", "4", "--", "src"],
+      "/repo",
+    );
+    expect(opts.mode).toBe("show");
+    expect(opts.from).toBe("HEAD");
+    expect(opts.maxDepth).toBe(4);
+    expect(opts.paths).toEqual(["src"]);
+  });
+
+  test("show requires --entry", () => {
+    expect(() => parseArgs(["show"], "/repo")).toThrow(
+      /show requires --entry/,
+    );
+  });
+
+  test("show rejects --from / --to", () => {
+    expect(() =>
+      parseArgs(["show", "--from", "a", "-e", "x"], "/repo"),
+    ).toThrow(/does not accept --from \/ --to/);
+  });
+
+  test("show rejects too many refs", () => {
+    expect(() =>
+      parseArgs(["show", "a", "b", "-e", "x"], "/repo"),
+    ).toThrow(/at most one ref/);
+  });
+
+  test("diff mode is unchanged for positionals", () => {
+    const opts = parseArgs(["main", "feature"], "/repo");
+    expect(opts.mode).toBe("diff");
+    expect(opts.from).toBe("main");
+    expect(opts.to).toBe("feature");
+  });
+
+  test("show --help does not require entry", () => {
+    const opts = parseArgs(["show", "--help"], "/repo");
+    expect(opts.mode).toBe("show");
+    expect(opts.help).toBe(true);
+  });
+});

--- a/test/callstack-show.test.ts
+++ b/test/callstack-show.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import { callstackShow } from "./helpers.js";
+
+describe("callstack show", () => {
+  test("renders a plain call tree without +/- markers", () => {
+    const actual = callstackShow(
+      `
+        export class PiService {
+          static createAgentSession(options: { sessionId?: string }) {
+            const services = PiService.getServices();
+            services.boot();
+            if (!options.sessionId) {
+              SessionManager.create();
+            } else {
+              SessionManager.open(options.sessionId);
+            }
+          }
+
+          static getServices() {
+            SettingsManager.create();
+            AuthStorage.create();
+            new ModelRegistry();
+            createCodingTools();
+            return { boot() {} };
+          }
+        }
+
+        class AuthStorage {
+          static create() {}
+        }
+
+        class ModelRegistry {
+          constructor() {}
+        }
+
+        class SessionManager {
+          static create() {}
+          static open(_id: string) {}
+        }
+
+        class SettingsManager {
+          static create() {}
+        }
+
+        function createCodingTools() {}
+      `,
+      "PiService.createAgentSession",
+    );
+
+    expect(actual).toBe(
+      [
+        "PiService.createAgentSession(options)",
+        "├─ PiService.getServices()",
+        "│  ├─ SettingsManager.create()",
+        "│  ├─ AuthStorage.create()",
+        "│  ├─ new ModelRegistry()",
+        "│  └─ createCodingTools()",
+        "├─ services.boot()",
+        "├─ if (!options.sessionId)",
+        "   └─ SessionManager.create()",
+        "└─ else",
+        "   └─ SessionManager.open(_id)",
+      ].join("\n"),
+    );
+  });
+
+  test("respects maxDepth", () => {
+    const actual = callstackShow(
+      `
+        export function outer() {
+          mid();
+        }
+        function mid() {
+          inner();
+        }
+        function inner() {
+          leaf();
+        }
+        function leaf() {}
+      `,
+      "outer",
+      { maxDepth: 1 },
+    );
+
+    expect(actual).toBe(["outer()", "└─ mid()"].join("\n"));
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,7 @@
 import { buildCallTree } from "../src/calltree.js";
 import { diffTrees } from "../src/diff.js";
 import { buildIndex, extractFunctions } from "../src/extract.js";
-import { renderDiff } from "../src/render.js";
+import { renderDiff, renderTree } from "../src/render.js";
 
 export type CallstackDiffOptions = {
   maxDepth?: number;
@@ -93,4 +93,20 @@ export function callstackDiff(
   const afterTree = buildCallTree(entry, after, maxDepth);
   const diff = diffTrees(beforeTree, afterTree);
   return renderDiff(diff, { color: false });
+}
+
+/**
+ * Expand a call tree for an entrypoint from a single source file.
+ * Returns colorless ASCII output (no +/- markers).
+ */
+export function callstackShow(
+  source: string,
+  entry: string,
+  options: CallstackDiffOptions = {},
+): string {
+  const maxDepth = options.maxDepth ?? 12;
+  const file = options.file ?? "file.ts";
+  const index = buildIndex(extractFunctions(file, source));
+  const tree = buildCallTree(entry, index, maxDepth);
+  return renderTree(tree, { color: false });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **`calldiff show`** subcommand to print ASCII call trees for explicit entrypoints from a single git snapshot (working tree or commit), without `+/−` diff markers.

Diff mode (`calldiff`, `calldiff <from>`, `calldiff <from> <to>`) is unchanged.

## CLI

```bash
calldiff show -e createAgentSession
calldiff show HEAD -e PiService.createAgentSession
calldiff show main -e boot --max-depth 8 -- src/lib
```

- `--entry` / `-e` is **required** for `show`
- No ref → working tree; one ref → that commit
- Rejects `--from` / `--to` in show mode

## Implementation

- `parseArgs`: `show` subcommand → `mode: "show"`
- `run.ts`: single `loadIndex` + `buildCallTree` + `renderTree`
- `renderTree`: shared ASCII renderer without status column
- Tests: `test/args.test.ts`, `test/callstack-show.test.ts`
- README + help updated

## Test plan

- [x] `npm run build`
- [x] `npm test -- test/args.test.ts test/callstack-show.test.ts test/callstack-diff.test.ts`
- [x] Smoke: `npm run dev -- show -e parseArgs -- src/args.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-478c14db-23a7-4d6d-916c-f9cd026dd9a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-478c14db-23a7-4d6d-916c-f9cd026dd9a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

