### PR TITLE
Add call-site source locations to tree/reach/diff output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ calldiff diff main feature src/lib
 calldiff tree -e createAgentSession
 calldiff tree HEAD -e PiService.createAgentSession
 calldiff tree main -e boot --max-depth 8 src/lib
+calldiff tree -e runCheckout --no-locs examples/checkout
 
 # find all call paths from one symbol to another — requires --entry and --to
 calldiff reach -e runCheckout --to sendEmail
@@ -86,6 +87,10 @@ If you omit `--entry`, calldiff infers exported functions whose expanded call tr
 | `calldiff tree <ref> -e <name>` | that commit/ref |
 
 Prints a plain ASCII call tree (no `+/−` markers). `--entry` / `-e` is required.
+Each node (except when disabled with `--no-locs`) shows a source location:
+the root uses the definition `file:line`, and children use the **call site** in
+the parent (`file:line` or `file:line-line`) — same idea as LSP Call Hierarchy
+`fromRanges`, not Go to Definition.
 
 ### `reach`
 
@@ -103,6 +108,7 @@ Prints every call path from the entrypoint to the target (including alternate `i
 - `new ClassName` — constructor / `new` call
 - `Component` — JSX/TSX component tags (`<Button />`); children nest under the parent
 - `if (cond)` / `else` / `else if (cond)` — conditional arms (no continuing `│` rail)
+- `file:line` — call-site (or root definition) location; toggle with `--locs` / `--no-locs` (default on)
 
 ### Supported languages
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ calldiff diff main feature src/lib
 calldiff tree -e createAgentSession
 calldiff tree HEAD -e PiService.createAgentSession
 calldiff tree main -e boot --max-depth 8 src/lib
-calldiff tree -e runCheckout --no-locs examples/checkout
+calldiff tree -e runCheckout --locs examples/checkout
 
 # find all call paths from one symbol to another — requires --entry and --to
 calldiff reach -e runCheckout --to sendEmail
@@ -87,10 +87,10 @@ If you omit `--entry`, calldiff infers exported functions whose expanded call tr
 | `calldiff tree <ref> -e <name>` | that commit/ref |
 
 Prints a plain ASCII call tree (no `+/−` markers). `--entry` / `-e` is required.
-Each node (except when disabled with `--no-locs`) shows a source location:
-the root uses the definition `file:line`, and children use the **call site** in
-the parent (`file:line` or `file:line-line`) — same idea as LSP Call Hierarchy
-`fromRanges`, not Go to Definition.
+With `--locs`, each node shows a source location: the root uses the definition
+`file:line`, and children use the **call site** in the parent (`file:line` or
+`file:line-line`) — same idea as LSP Call Hierarchy `fromRanges`, not Go to
+Definition.
 
 ### `reach`
 
@@ -108,7 +108,7 @@ Prints every call path from the entrypoint to the target (including alternate `i
 - `new ClassName` — constructor / `new` call
 - `Component` — JSX/TSX component tags (`<Button />`); children nest under the parent
 - `if (cond)` / `else` / `else if (cond)` — conditional arms (no continuing `│` rail)
-- `file:line` — call-site (or root definition) location; toggle with `--locs` / `--no-locs` (default on)
+- `file:line` — call-site (or root definition) location; enable with `--locs` (default off)
 
 ### Supported languages
 

--- a/src/calltree.ts
+++ b/src/calltree.ts
@@ -1,4 +1,5 @@
 import type { FunctionIndex } from "./extract.js";
+import { pickLoc } from "./loc.js";
 import type { CallNode, CallStep } from "./types.js";
 
 function displayCallLabel(key: string, index: FunctionIndex): string {
@@ -20,6 +21,7 @@ function expandSteps(
         key: step.key,
         label: step.label,
         kind: "branch" as const,
+        ...pickLoc(step),
         children: expandSteps(
           step.children,
           index,
@@ -36,6 +38,7 @@ function expandSteps(
       maxDepth,
       visiting,
       step.children,
+      step,
     );
   });
 }
@@ -47,16 +50,23 @@ function expandCall(
   maxDepth: number,
   visiting: Set<string>,
   inlineChildren?: CallStep[],
+  callSite?: { file?: string; line?: number; endLine?: number },
 ): CallNode {
   const label = displayCallLabel(key, index);
+  const info = index.get(key);
+
+  // Root uses the definition start line; every other node uses the call-site in the parent.
+  const loc =
+    depth === 0 && info?.line != null
+      ? pickLoc({ file: info.file, line: info.line })
+      : pickLoc(callSite);
 
   if (depth >= maxDepth) {
-    return { key, label, kind: "call", children: [] };
+    return { key, label, kind: "call", ...loc, children: [] };
   }
 
-  const info = index.get(key);
   if (!info && !inlineChildren?.length) {
-    return { key, label, kind: "call", children: [] };
+    return { key, label, kind: "call", ...loc, children: [] };
   }
 
   if (info && visiting.has(key)) {
@@ -68,6 +78,7 @@ function expandCall(
       key,
       label: `${label} ⇄`,
       kind: "call",
+      ...loc,
       children: callSiteChildren,
     };
   }
@@ -85,6 +96,7 @@ function expandCall(
     key,
     label,
     kind: "call",
+    ...loc,
     children: [...bodyChildren, ...callSiteChildren],
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,6 +75,11 @@ const maxDepthOption = z.coerce
   .default(12)
   .describe("Max call-tree depth");
 
+const locsOption = z
+  .boolean()
+  .default(true)
+  .describe("Show call-site source locations (file:line)");
+
 const pathsArg = z
   .array(z.string())
   .optional()
@@ -105,6 +110,7 @@ export const cli = Cli.create("calldiff", {
     options: z.object({
       entry: entryOption.optional(),
       maxDepth: maxDepthOption,
+      locs: locsOption,
       from: z.string().optional().describe('Left / "before" tree'),
       to: z.string().optional().describe('Right / "after" tree'),
     }),
@@ -145,6 +151,7 @@ export const cli = Cli.create("calldiff", {
           entries,
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
+          locs: c.options.locs,
           color: !c.formatExplicit && !c.agent,
         });
       } catch (error) {
@@ -183,6 +190,7 @@ export const cli = Cli.create("calldiff", {
     options: z.object({
       entry: entryOption,
       maxDepth: maxDepthOption,
+      locs: locsOption,
     }),
     alias: { entry: "e" },
     examples: [
@@ -212,6 +220,7 @@ export const cli = Cli.create("calldiff", {
           entries,
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
+          locs: c.options.locs,
           color: !c.formatExplicit && !c.agent,
         });
         return emitAsciiOrData(c, result);
@@ -239,6 +248,7 @@ export const cli = Cli.create("calldiff", {
         .string()
         .describe("Target symbol to reach (functionName or ClassName.method)"),
       maxDepth: maxDepthOption,
+      locs: locsOption,
     }),
     alias: { entry: "e" },
     examples: [
@@ -276,6 +286,7 @@ export const cli = Cli.create("calldiff", {
           to: c.options.to,
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
+          locs: c.options.locs,
           color: !c.formatExplicit && !c.agent,
         });
         return emitAsciiOrData(c, result);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ const maxDepthOption = z.coerce
 
 const locsOption = z
   .boolean()
-  .default(true)
+  .default(false)
   .describe("Show call-site source locations (file:line)");
 
 const pathsArg = z

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,3 +1,4 @@
+import { pickLoc } from "./loc.js";
 import type { CallNode, DiffNode } from "./types.js";
 
 /**
@@ -14,6 +15,7 @@ function diffNode(before: CallNode | null, after: CallNode | null): DiffNode {
       key: after.key,
       label: after.label,
       kind: after.kind ?? before.kind,
+      ...pickLoc(after.file ? after : before),
       status: "same",
       children: diffChildren(before.children, after.children),
     };
@@ -24,6 +26,7 @@ function diffNode(before: CallNode | null, after: CallNode | null): DiffNode {
       key: after.key,
       label: after.label,
       kind: after.kind,
+      ...pickLoc(after),
       status: "added",
       children: after.children.map(markTree("added")),
     };
@@ -34,6 +37,7 @@ function diffNode(before: CallNode | null, after: CallNode | null): DiffNode {
       key: before.key,
       label: before.label,
       kind: before.kind,
+      ...pickLoc(before),
       status: "removed",
       children: before.children.map(markTree("removed")),
     };
@@ -48,6 +52,7 @@ function markTree(status: "added" | "removed") {
       key: node.key,
       label: node.label,
       kind: node.kind,
+      ...pickLoc(node),
       status,
       children: node.children.map(mark),
     };

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -6,6 +6,7 @@ import Parser from "tree-sitter";
 import type { CallStep, FunctionInfo } from "./types.js";
 import { loadGrammarPackage, resolveLanguage } from "./languages/grammars.js";
 import { detectLanguage } from "./languages/registry.js";
+import { linesFromOffsets } from "./loc.js";
 
 const parser = new Parser();
 const languageCache = new Map<string, unknown>();
@@ -38,7 +39,11 @@ export function extractFunctions(
   );
   parser.setLanguage(language as any);
   const tree = parser.parse(source);
-  return extractor.extract(file, source, tree);
+  return extractor.extract(file, source, tree).map((fn) => {
+    if (fn.line != null) return fn;
+    const lines = linesFromOffsets(source, fn.start, fn.end);
+    return { ...fn, ...lines };
+  });
 }
 
 export type FunctionIndex = Map<string, FunctionInfo>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { cli, normalizeArgv } from "./cli.js";
 export { buildCallTree, resolveEntry } from "./calltree.js";
 export { diffTrees, treeHasChanges } from "./diff.js";
 export { buildIndex, extractFunctions } from "./extract.js";
+export { formatSourceLoc, pickLoc } from "./loc.js";
 export { collectPathsTo, findReachPaths, pathToTree } from "./reach.js";
 export { renderDiff, renderTree } from "./render.js";
 export { runDiff, runReach, runTree } from "./run.js";

--- a/src/languages/CONTRACT.md
+++ b/src/languages/CONTRACT.md
@@ -14,6 +14,7 @@ Helpers: `namedChildren`, `childByType`, `collapseWs` from `./types.js`.
 - `key`: stable id (`foo`, `Type.method`, `new Type`)
 - `label`: display with params (`foo(x)`, `Type.method()`)
 - `steps`: ordered `call` | `branch` (`if`/`else`/`elif`/language equivalent)
+- Call and branch steps should include call-site / keyword locs via `locFromNode(file, node)` → `file`, `line`, optional `endLine` (1-based)
 - `exported`: used for entry inference
 
 ## Must support

--- a/src/languages/bash.ts
+++ b/src/languages/bash.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -63,15 +64,15 @@ function commandName(cmd: SyntaxNode): string | null {
   return text;
 }
 
-function collectStatements(statements: SyntaxNode[]): CallStep[] {
+function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -118,7 +119,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if ${condText}` : "if",
-        children: collectStatements(thenStmts),
+        ...locFromNode(file, test ?? node),
+        children: collectStatements(file, thenStmts),
       });
 
       for (const clause of elifClauses) {
@@ -131,7 +133,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
           type: "branch",
           key: text ? `else-if:${text}` : "else-if",
           label: text ? `elif ${text}` : "elif",
-          children: collectStatements(body),
+          ...locFromNode(file, elifTest ?? clause),
+          children: collectStatements(file, body),
         });
       }
 
@@ -140,7 +143,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
           type: "branch",
           key: "else",
           label: "else",
-          children: collectStatements(namedChildren(elseClause)),
+          ...locFromNode(file, elseClause),
+          children: collectStatements(file, namedChildren(elseClause)),
         });
       }
       return;
@@ -166,7 +170,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
           type: "branch",
           key: text ? `case:${text}` : "case",
           label: text ? `case ${text}` : "case",
-          children: collectStatements(body),
+          ...locFromNode(file, pattern ?? item),
+          children: collectStatements(file, body),
         });
       }
       return;
@@ -174,7 +179,7 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
 
     if (node.type === "command") {
       const name = commandName(node);
-      if (name) addCall(name, node.startIndex);
+      if (name) addCall(name, node);
       // Walk args / substitutions (including when the name itself is $(...))
       for (const child of namedChildren(node)) {
         if (name && child.type === "command_name") continue;
@@ -215,7 +220,7 @@ function handleFunction(
     key: name,
     label: `${name}()`,
     file,
-    steps: collectStatements(stmts),
+    steps: collectStatements(file, stmts),
     exported: true,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/c.ts
+++ b/src/languages/c.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -97,15 +98,15 @@ function condText(node: SyntaxNode | null): string {
   return collapseWs(node.text);
 }
 
-function collectStatements(statements: SyntaxNode[]): CallStep[] {
+function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -127,7 +128,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
         type: "branch",
         key: text ? `if:${text}` : "if",
         label: text ? `if ${text}` : "if",
-        children: consequent ? collectStatements([consequent]) : [],
+        ...locFromNode(file, cond ?? node),
+        children: consequent ? collectStatements(file, [consequent]) : [],
       });
 
       let elseClause = childByType(node, "else_clause");
@@ -151,7 +153,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",
             label: elifText ? `else if ${elifText}` : "else if",
-            children: elifCons ? collectStatements([elifCons]) : [],
+            ...locFromNode(file, elifCond ?? elseClause),
+            children: elifCons ? collectStatements(file, [elifCons]) : [],
           });
           elseClause = childByType(inner, "else_clause");
           continue;
@@ -160,7 +163,8 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
           type: "branch",
           key: "else",
           label: "else",
-          children: collectStatements([inner]),
+          ...locFromNode(file, elseClause),
+          children: collectStatements(file, [inner]),
         });
         break;
       }
@@ -184,14 +188,16 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
               type: "branch",
               key: `case:${text}`,
               label: `case ${text}`,
-              children: collectStatements(kids),
+              ...locFromNode(file, value),
+              children: collectStatements(file, kids),
             });
           } else {
             steps.push({
               type: "branch",
               key: "default",
               label: "default",
-              children: collectStatements(kids),
+              ...locFromNode(file, clause),
+              children: collectStatements(file, kids),
             });
           }
         }
@@ -203,7 +209,7 @@ function collectStatements(statements: SyntaxNode[]): CallStep[] {
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     }
 
@@ -226,7 +232,7 @@ function handleFunction(
     key: name,
     label: `${name}${getParamsLabel(node)}`,
     file,
-    steps: body ? collectStatements(namedChildren(body)) : [],
+    steps: body ? collectStatements(file, namedChildren(body)) : [],
     exported: !hasStatic(node),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/cpp.ts
+++ b/src/languages/cpp.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -82,17 +83,18 @@ function condText(node: SyntaxNode | null): string {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -124,8 +126,9 @@ function collectStatements(
         type: "branch",
         key: text ? `if:${text}` : "if",
         label: text ? `if ${text}` : "if",
+        ...locFromNode(file, cond ?? node),
         children: consequent
-          ? collectStatements([consequent], className)
+          ? collectStatements(file, [consequent], className)
           : [],
       });
 
@@ -151,8 +154,9 @@ function collectStatements(
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",
             label: elifText ? `else if ${elifText}` : "else if",
+            ...locFromNode(file, elifCond ?? elseClause),
             children: elifCons
-              ? collectStatements([elifCons], className)
+              ? collectStatements(file, [elifCons], className)
               : [],
           });
           elseClause = childByType(inner, "else_clause");
@@ -162,7 +166,8 @@ function collectStatements(
           type: "branch",
           key: "else",
           label: "else",
-          children: collectStatements([inner], className),
+          ...locFromNode(file, elseClause),
+          children: collectStatements(file, [inner], className),
         });
         break;
       }
@@ -177,8 +182,9 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
+        ...locFromNode(file, node),
         children: body
-          ? collectStatements(namedChildren(body), className)
+          ? collectStatements(file, namedChildren(body), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -192,8 +198,9 @@ function collectStatements(
           type: "branch",
           key: text ? `catch:${text}` : "catch",
           label: text ? `catch ${text}` : "catch",
+          ...locFromNode(file, params ?? clause),
           children: catchBody
-            ? collectStatements(namedChildren(catchBody), className)
+            ? collectStatements(file, namedChildren(catchBody), className)
             : [],
         });
       }
@@ -204,7 +211,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     } else if (node.type === "new_expression") {
       const typeId =
@@ -215,7 +222,7 @@ function collectStatements(
         null;
       if (typeId) {
         const name = collapseWs(typeId.text);
-        addCall(`new ${name}`, node.startIndex);
+        addCall(`new ${name}`, node);
       }
     }
 
@@ -241,7 +248,7 @@ function pushFunction(
     key,
     label: `${label}${getParamsLabel(declarator)}`,
     file,
-    steps: body ? collectStatements(namedChildren(body), className) : [],
+    steps: body ? collectStatements(file, namedChildren(body), className) : [],
     exported,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -68,17 +69,18 @@ function condText(node: SyntaxNode | null): string {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -107,8 +109,10 @@ function collectStatements(
         type: "branch",
         key: text ? `if:${text}` : "if",
         label: text ? `if ${text}` : "if",
+        ...locFromNode(file, cond ?? node),
         children: consequent
           ? collectStatements(
+              file,
               consequent.type === "block"
                 ? namedChildren(consequent)
                 : [consequent],
@@ -131,8 +135,10 @@ function collectStatements(
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",
             label: elifText ? `else if ${elifText}` : "else if",
+            ...locFromNode(file, elifCond ?? alternative),
             children: elifCons
               ? collectStatements(
+                  file,
                   elifCons.type === "block"
                     ? namedChildren(elifCons)
                     : [elifCons],
@@ -147,7 +153,9 @@ function collectStatements(
           type: "branch",
           key: "else",
           label: "else",
+          ...locFromNode(file, alternative),
           children: collectStatements(
+            file,
             alternative.type === "block"
               ? namedChildren(alternative)
               : [alternative],
@@ -166,8 +174,9 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
+        ...locFromNode(file, node),
         children: body
-          ? collectStatements(namedChildren(body), className)
+          ? collectStatements(file, namedChildren(body), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -180,8 +189,9 @@ function collectStatements(
             type: "branch",
             key: text ? `catch:${text}` : "catch",
             label: text ? `catch ${text}` : "catch",
+            ...locFromNode(file, decl ?? clause),
             children: catchBody
-              ? collectStatements(namedChildren(catchBody), className)
+              ? collectStatements(file, namedChildren(catchBody), className)
               : [],
           });
         }
@@ -192,8 +202,9 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
+            ...locFromNode(file, clause),
             children: finallyBody
-              ? collectStatements(namedChildren(finallyBody), className)
+              ? collectStatements(file, namedChildren(finallyBody), className)
               : [],
           });
         }
@@ -232,7 +243,8 @@ function collectStatements(
               type: "branch",
               key: "default",
               label: "default",
-              children: collectStatements(stmts, className),
+              ...locFromNode(file, section),
+              children: collectStatements(file, stmts, className),
             });
           } else {
             const text = pattern ? collapseWs(pattern.text) : "";
@@ -240,7 +252,8 @@ function collectStatements(
               type: "branch",
               key: text ? `case:${text}` : "case",
               label: text ? `case ${text}` : "case",
-              children: collectStatements(stmts, className),
+              ...locFromNode(file, pattern ?? section),
+              children: collectStatements(file, stmts, className),
             });
           }
         }
@@ -252,7 +265,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     } else if (node.type === "object_creation_expression") {
       const typeId =
@@ -263,7 +276,7 @@ function collectStatements(
         ) ??
         null;
       if (typeId) {
-        addCall(`new ${collapseWs(typeId.text)}`, node.startIndex);
+        addCall(`new ${collapseWs(typeId.text)}`, node);
       }
     }
 
@@ -294,7 +307,7 @@ function handleMethod(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(namedChildren(body), className) : [],
+    steps: body ? collectStatements(file, namedChildren(body), className) : [],
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,
@@ -313,7 +326,7 @@ function handleConstructor(
     key: `${className}.constructor`,
     label: `new ${className}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(namedChildren(body), className) : [],
+    steps: body ? collectStatements(file, namedChildren(body), className) : [],
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/elixir.ts
+++ b/src/languages/elixir.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -116,25 +117,27 @@ function bodyOfDef(call: SyntaxNode): SyntaxNode | null {
 }
 
 function collectBody(
+  file: string,
   body: SyntaxNode | null,
   moduleName: string | null,
 ): CallStep[] {
   if (!body) return [];
-  return collectStatements(namedChildren(body), moduleName);
+  return collectStatements(file, namedChildren(body), moduleName);
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   moduleName: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -159,14 +162,16 @@ function collectStatements(
           type: "branch",
           key: condText ? `if:${condText}` : "if",
           label: condText ? `if ${condText}` : "if",
-          children: collectStatements(thenKids, moduleName),
+          ...locFromNode(file, cond ?? node),
+          children: collectStatements(file, thenKids, moduleName),
         });
         if (elseBlock) {
           steps.push({
             type: "branch",
             key: "else",
             label: "else",
-            children: collectBody(elseBlock, moduleName),
+            ...locFromNode(file, elseBlock),
+            children: collectBody(file, elseBlock, moduleName),
           });
         }
         // cond may contain calls — walk it
@@ -184,7 +189,8 @@ function collectStatements(
             type: "branch",
             key: text ? `case:${text}` : "case",
             label: text ? `case ${text}` : "case",
-            children: body ? collectBody(body, moduleName) : [],
+            ...locFromNode(file, pattern ?? clause),
+            children: body ? collectBody(file, body, moduleName) : [],
           });
         }
         return;
@@ -200,7 +206,8 @@ function collectStatements(
             type: "branch",
             key: text ? `cond:${text}` : "cond",
             label: text ? `cond ${text}` : "cond",
-            children: body ? collectBody(body, moduleName) : [],
+            ...locFromNode(file, pattern ?? clause),
+            children: body ? collectBody(file, body, moduleName) : [],
           });
         }
         return;
@@ -220,7 +227,8 @@ function collectStatements(
           type: "branch",
           key: "try",
           label: "try",
-          children: collectStatements(tryKids, moduleName),
+          ...locFromNode(file, node),
+          children: collectStatements(file, tryKids, moduleName),
         });
         const rescue = doBlock ? childByType(doBlock, "rescue_block") : null;
         if (rescue) {
@@ -233,7 +241,8 @@ function collectStatements(
               type: "branch",
               key: text ? `rescue:${text}` : "rescue",
               label: text ? `rescue ${text}` : "rescue",
-              children: body ? collectBody(body, moduleName) : [],
+              ...locFromNode(file, pattern ?? clause),
+              children: body ? collectBody(file, body, moduleName) : [],
             });
           }
         }
@@ -243,7 +252,8 @@ function collectStatements(
             type: "branch",
             key: "after",
             label: "after",
-            children: collectBody(after, moduleName),
+            ...locFromNode(file, after),
+            children: collectBody(file, after, moduleName),
           });
         }
         return;
@@ -256,7 +266,7 @@ function collectStatements(
       const hasExplicitArgs = args !== null;
       if (callee && callee.type !== "do_block") {
         const key = calleeKey(callee, moduleName, hasExplicitArgs);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       // Walk args for nested calls, but skip field-ish dots without further calls
       if (args) walk(args);
@@ -290,7 +300,7 @@ function handleDef(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: collectBody(body, moduleName),
+    steps: collectBody(file, body, moduleName),
     exported,
     start: call.startIndex,
     end: call.endIndex,

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -69,6 +70,7 @@ function statementsOf(node: SyntaxNode): SyntaxNode[] {
 }
 
 function collectIf(
+  file: string,
   node: SyntaxNode,
   receiverType: string | null,
   steps: CallStep[],
@@ -91,36 +93,39 @@ function collectIf(
     type: "branch",
     key: condText ? `${kind}:${condText}` : kind,
     label: condText ? `${labelKind} ${condText}` : labelKind,
+    ...locFromNode(file, condNode ?? node),
     children: consequent
-      ? collectStatements(statementsOf(consequent), receiverType)
+      ? collectStatements(file, statementsOf(consequent), receiverType)
       : [],
   });
 
   if (!alt) return;
   if (alt.type === "if_statement") {
-    collectIf(alt, receiverType, steps, true);
+    collectIf(file, alt, receiverType, steps, true);
   } else {
     steps.push({
       type: "branch",
       key: "else",
       label: "else",
-      children: collectStatements(statementsOf(alt), receiverType),
+      ...locFromNode(file, alt),
+      children: collectStatements(file, statementsOf(alt), receiverType),
     });
   }
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   receiverType: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -133,7 +138,7 @@ function collectStatements(
     }
 
     if (node.type === "if_statement") {
-      collectIf(node, receiverType, steps, false);
+      collectIf(file, node, receiverType, steps, false);
       return;
     }
 
@@ -142,7 +147,8 @@ function collectStatements(
         type: "branch",
         key: "defer",
         label: "defer",
-        children: collectStatements(namedChildren(node), receiverType),
+        ...locFromNode(file, node),
+        children: collectStatements(file, namedChildren(node), receiverType),
       });
       return;
     }
@@ -177,8 +183,9 @@ function collectStatements(
               : subjectText
                 ? `case ${subjectText}`
                 : "case",
+            ...locFromNode(file, expr ?? clause),
             children: list
-              ? collectStatements(namedChildren(list), receiverType)
+              ? collectStatements(file, namedChildren(list), receiverType)
               : [],
           });
         }
@@ -188,8 +195,9 @@ function collectStatements(
             type: "branch",
             key: "default",
             label: "default",
+            ...locFromNode(file, clause),
             children: list
-              ? collectStatements(namedChildren(list), receiverType)
+              ? collectStatements(file, namedChildren(list), receiverType)
               : [],
           });
         }
@@ -201,7 +209,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee && callee.type !== "func_literal") {
         const key = calleeKey(callee, receiverType);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       // Do not walk into func_literal callees/bodies
       for (const child of namedChildren(node)) {
@@ -245,7 +253,7 @@ function handleFunction(
     key: name,
     label: `${name}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), null) : [],
+    steps: body ? collectStatements(file, statementsOf(body), null) : [],
     exported: isExported(name),
     start: node.startIndex,
     end: node.endIndex,
@@ -285,7 +293,7 @@ function handleMethod(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), typeName) : [],
+    steps: body ? collectStatements(file, statementsOf(body), typeName) : [],
     exported: isExported(name),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/haskell.ts
+++ b/src/languages/haskell.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -67,22 +68,22 @@ function calleeFromExp(node: SyntaxNode): string | null {
   return null;
 }
 
-function collectFromMatch(match: SyntaxNode | null): CallStep[] {
+function collectFromMatch(file: string, match: SyntaxNode | null): CallStep[] {
   if (!match) return [];
   const body = match.namedChild(0) ?? namedChildren(match)[0] ?? null;
   if (!body) return [];
-  return collectExpr(body);
+  return collectExpr(file, body);
 }
 
-function collectExpr(node: SyntaxNode): CallStep[] {
+function collectExpr(file: string, node: SyntaxNode): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (n: SyntaxNode): void => {
@@ -107,14 +108,16 @@ function collectExpr(node: SyntaxNode): CallStep[] {
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if ${condText}` : "if",
-        children: thenE ? collectExpr(thenE) : [],
+        ...locFromNode(file, cond ?? n),
+        children: thenE ? collectExpr(file, thenE) : [],
       });
       if (elseE) {
         steps.push({
           type: "branch",
           key: "else",
           label: "else",
-          children: collectExpr(elseE),
+          ...locFromNode(file, elseE),
+          children: collectExpr(file, elseE),
         });
       }
       return;
@@ -132,7 +135,8 @@ function collectExpr(node: SyntaxNode): CallStep[] {
           type: "branch",
           key: text ? `case:${text}` : "case",
           label: text ? `case ${text}` : "case",
-          children: collectFromMatch(match),
+          ...locFromNode(file, pattern ?? alt),
+          children: collectFromMatch(file, match),
         });
       }
       return;
@@ -142,7 +146,7 @@ function collectExpr(node: SyntaxNode): CallStep[] {
       const key = calleeFromExp(n);
       // Skip type-like constructors: Just x, Runner
       if (key && !isLikelyTypeName(key.split(".").pop() ?? key)) {
-        addCall(key, n.startIndex);
+        addCall(key, n);
       }
       // Walk argument expressions for nested applies, but not bare variable args
       for (const child of namedChildren(n).slice(1)) {
@@ -162,7 +166,7 @@ function collectExpr(node: SyntaxNode): CallStep[] {
     if (n.type === "variable") {
       // Bare variable used as expression in do-block is a call-ish nullary
       if (n.text !== "return" && n.text !== "pure" && !isLikelyTypeName(n.text)) {
-        addCall(n.text, n.startIndex);
+        addCall(n.text, n);
       }
       return;
     }
@@ -170,7 +174,7 @@ function collectExpr(node: SyntaxNode): CallStep[] {
     if (n.type === "qualified") {
       const key = calleeFromExp(n);
       if (key && !isLikelyTypeName(key.split(".").pop() ?? key)) {
-        addCall(key, n.startIndex);
+        addCall(key, n);
       }
       return;
     }
@@ -222,7 +226,7 @@ function handleFunctionOrBind(
     key: name,
     label: `${name}${getParamsLabel(patterns)}`,
     file,
-    steps: collectFromMatch(match),
+    steps: collectFromMatch(file, match),
     exported: true,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -79,17 +80,18 @@ function statementsOf(node: SyntaxNode): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -128,8 +130,9 @@ function collectStatements(
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if (${condText})` : "if",
+        ...locFromNode(file, condInner ?? node),
         children: consequent
-          ? collectStatements(statementsOf(consequent), className)
+          ? collectStatements(file, statementsOf(consequent), className)
           : [],
       });
 
@@ -140,14 +143,15 @@ function collectStatements(
           type: "branch",
           key: "else",
           label: "else",
-          children: collectStatements(statementsOf(alternate), className),
+          ...locFromNode(file, alternate),
+          children: collectStatements(file, statementsOf(alternate), className),
         });
       } else {
         // Look for else-if: a trailing if_statement child
         const elseIf = kids.find((c) => c.type === "if_statement");
         if (elseIf) {
           // Flatten: treat nested if as else-if / else chain
-          const nested = collectStatements([elseIf], className);
+          const nested = collectStatements(file, [elseIf], className);
           for (const step of nested) {
             if (step.type === "branch" && step.key.startsWith("if:")) {
               steps.push({
@@ -170,8 +174,9 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
+        ...locFromNode(file, node),
         children: tryBlock
-          ? collectStatements(statementsOf(tryBlock), className)
+          ? collectStatements(file, statementsOf(tryBlock), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -195,8 +200,9 @@ function collectStatements(
             type: "branch",
             key: text ? `catch:${text}` : "catch",
             label: text ? `catch (${text})` : "catch",
+            ...locFromNode(file, typeNode ?? clause),
             children: block
-              ? collectStatements(statementsOf(block), className)
+              ? collectStatements(file, statementsOf(block), className)
               : [],
           });
         }
@@ -206,8 +212,9 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
+            ...locFromNode(file, clause),
             children: block
-              ? collectStatements(statementsOf(block), className)
+              ? collectStatements(file, statementsOf(block), className)
               : [],
           });
         }
@@ -239,7 +246,8 @@ function collectStatements(
                 type: "branch",
                 key: "default",
                 label: "default",
-                children: collectStatements(stmts, className),
+                ...locFromNode(file, label),
+                children: collectStatements(file, stmts, className),
               });
             } else {
               const value = label.namedChild(0);
@@ -248,7 +256,8 @@ function collectStatements(
                 type: "branch",
                 key: text ? `case:${text}` : "case",
                 label: text ? `case ${text}` : "case",
-                children: collectStatements(stmts, className),
+                ...locFromNode(file, value ?? label),
+                children: collectStatements(file, stmts, className),
               });
             }
           }
@@ -261,13 +270,14 @@ function collectStatements(
           const isDefault =
             label.namedChildCount === 0 || /\bdefault\b/.test(label.text);
           const children = bodyNode
-            ? collectStatements(statementsOf(bodyNode), className)
+            ? collectStatements(file, statementsOf(bodyNode), className)
             : [];
           if (isDefault) {
             steps.push({
               type: "branch",
               key: "default",
               label: "default",
+              ...locFromNode(file, label),
               children,
             });
           } else {
@@ -277,6 +287,7 @@ function collectStatements(
               type: "branch",
               key: text ? `case:${text}` : "case",
               label: text ? `case ${text}` : "case",
+              ...locFromNode(file, value ?? label),
               children,
             });
           }
@@ -287,7 +298,7 @@ function collectStatements(
 
     if (node.type === "method_invocation") {
       const key = methodInvocationKey(node, className);
-      if (key) addCall(key, node.startIndex);
+      if (key) addCall(key, node);
     } else if (node.type === "object_creation_expression") {
       const typeId =
         childByType(node, "type_identifier") ??
@@ -296,7 +307,7 @@ function collectStatements(
         typeId?.type === "type_identifier"
           ? typeId.text
           : childByType(typeId ?? node, "type_identifier")?.text;
-      if (name) addCall(`new ${name}`, node.startIndex);
+      if (name) addCall(`new ${name}`, node);
     }
 
     for (const child of namedChildren(node)) walk(child);
@@ -321,7 +332,7 @@ function handleMethod(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), className) : [],
+    steps: body ? collectStatements(file, statementsOf(body), className) : [],
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,
@@ -340,7 +351,7 @@ function handleConstructor(
     key: `${className}.constructor`,
     label: `new ${className}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), className) : [],
+    steps: body ? collectStatements(file, statementsOf(body), className) : [],
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/javascript.ts
+++ b/src/languages/javascript.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -139,17 +140,18 @@ function statementsOf(node: SyntaxNode): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seenCalls = new Set<string>();
 
-  const addCall = (key: string, startIndex: number) => {
-    const mark = `${key}:${startIndex}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seenCalls.has(mark)) return;
     seenCalls.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walkExpr = (node: SyntaxNode): void => {
@@ -177,8 +179,9 @@ function collectStatements(
         type: "branch",
         key: branchKey("if", cond),
         label: test ? `if (${condText(test)})` : "if",
+        ...locFromNode(file, test ?? node),
         children: consequent
-          ? collectStatements(statementsOf(consequent), className)
+          ? collectStatements(file, statementsOf(consequent), className)
           : [],
       });
 
@@ -202,8 +205,9 @@ function collectStatements(
             type: "branch",
             key: branchKey("else-if", elseCond),
             label: elseTest ? `else if (${condText(elseTest)})` : "else if",
+            ...locFromNode(file, elseTest ?? current),
             children: elseConsequent
-              ? collectStatements(statementsOf(elseConsequent), className)
+              ? collectStatements(file, statementsOf(elseConsequent), className)
               : [],
           });
           current = childByType(inner, "else_clause");
@@ -214,7 +218,8 @@ function collectStatements(
           type: "branch",
           key: branchKey("else", ""),
           label: "else",
-          children: collectStatements(statementsOf(inner), className),
+          ...locFromNode(file, current),
+          children: collectStatements(file, statementsOf(inner), className),
         });
         break;
       }
@@ -227,8 +232,9 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
+        ...locFromNode(file, node),
         children: tryBlock
-          ? collectStatements(statementsOf(tryBlock), className)
+          ? collectStatements(file, statementsOf(tryBlock), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -243,8 +249,9 @@ function collectStatements(
             type: "branch",
             key: text ? `catch:${text}` : "catch",
             label: text ? `catch (${text})` : "catch",
+            ...locFromNode(file, param ?? clause),
             children: block
-              ? collectStatements(statementsOf(block), className)
+              ? collectStatements(file, statementsOf(block), className)
               : [],
           });
         }
@@ -254,8 +261,9 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
+            ...locFromNode(file, clause),
             children: block
-              ? collectStatements(statementsOf(block), className)
+              ? collectStatements(file, statementsOf(block), className)
               : [],
           });
         }
@@ -306,7 +314,8 @@ function collectStatements(
             type: "branch",
             key: text ? `case:${text}` : "case",
             label: text ? `case ${text}` : "case",
-            children: collectStatements(stmts, className),
+            ...locFromNode(file, caseValue ?? clause),
+            children: collectStatements(file, stmts, className),
           });
         }
         if (clause.type === "switch_default") {
@@ -317,7 +326,8 @@ function collectStatements(
             type: "branch",
             key: "default",
             label: "default",
-            children: collectStatements(stmts, className),
+            ...locFromNode(file, clause),
+            children: collectStatements(file, stmts, className),
           });
         }
       }
@@ -328,14 +338,14 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     } else if (type === "new_expression") {
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, null);
         if (key) {
-          addCall(key.startsWith("new ") ? key : `new ${key}`, node.startIndex);
+          addCall(key.startsWith("new ") ? key : `new ${key}`, node);
         }
       }
     } else if (type === "jsx_element") {
@@ -351,21 +361,26 @@ function collectStatements(
             attr.type === "jsx_attribute" ||
             attr.type === "jsx_expression"
           ) {
-            fromAttrs.push(...collectStatements([attr], className));
+            fromAttrs.push(...collectStatements(file, [attr], className));
           }
         }
       }
       const nested = [
         ...fromAttrs,
-        ...collectStatements(childNodes, className),
+        ...collectStatements(file, childNodes, className),
       ];
       if (opening) {
         const key = jsxCalleeKey(opening);
         if (key) {
           if (nested.length > 0) {
-            steps.push({ type: "call", key, children: nested });
+            steps.push({
+              type: "call",
+              key,
+              ...locFromNode(file, opening),
+              children: nested,
+            });
           } else {
-            addCall(key, opening.startIndex);
+            addCall(key, opening);
           }
           return;
         }
@@ -376,13 +391,18 @@ function collectStatements(
       const attrNodes = namedChildren(node).filter(
         (c) => c.type === "jsx_attribute" || c.type === "jsx_expression",
       );
-      const nested = collectStatements(attrNodes, className);
+      const nested = collectStatements(file, attrNodes, className);
       const key = jsxCalleeKey(node);
       if (key) {
         if (nested.length > 0) {
-          steps.push({ type: "call", key, children: nested });
+          steps.push({
+            type: "call",
+            key,
+            ...locFromNode(file, node),
+            children: nested,
+          });
         } else {
-          addCall(key, node.startIndex);
+          addCall(key, node);
         }
       } else {
         for (const step of nested) steps.push(step);
@@ -403,14 +423,15 @@ function collectStatements(
 }
 
 function collectStepsFromBody(
+  file: string,
   body: SyntaxNode | null,
   className: string | null,
 ): CallStep[] {
   if (!body) return [];
   if (body.type === "statement_block") {
-    return collectStatements(namedChildren(body), className);
+    return collectStatements(file, namedChildren(body), className);
   }
-  return collectStatements([body], className);
+  return collectStatements(file, [body], className);
 }
 
 function functionFromParts(
@@ -428,7 +449,7 @@ function functionFromParts(
     key,
     label: `${label}${getParamsLabel(params)}`,
     file,
-    steps: collectStepsFromBody(body, className),
+    steps: collectStepsFromBody(file, body, className),
     exported,
     start,
     end,

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -77,17 +78,18 @@ function statementsOf(body: SyntaxNode | null): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const pushIfChain = (node: SyntaxNode, asElseIf: boolean): void => {
@@ -103,7 +105,12 @@ function collectStatements(
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,
       label: condText ? `${labelKind} ${condText}` : labelKind,
-      children: collectStatements(statementsOf(bodies[0] ?? null), className),
+      ...locFromNode(file, cond ?? node),
+      children: collectStatements(
+        file,
+        statementsOf(bodies[0] ?? null),
+        className,
+      ),
     });
 
     if (!bodies[1]) return;
@@ -118,7 +125,8 @@ function collectStatements(
       type: "branch",
       key: "else",
       label: "else",
-      children: collectStatements(elseStmts, className),
+      ...locFromNode(file, bodies[1]),
+      children: collectStatements(file, elseStmts, className),
     });
   };
 
@@ -147,8 +155,9 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
+        ...locFromNode(file, node),
         children: tryStmts
-          ? collectStatements(namedChildren(tryStmts), className)
+          ? collectStatements(file, namedChildren(tryStmts), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -166,8 +175,9 @@ function collectStatements(
             type: "branch",
             key: text ? `catch:${text}` : "catch",
             label: text ? `catch ${text}` : "catch",
+            ...locFromNode(file, type ?? clause),
             children: body
-              ? collectStatements(namedChildren(body), className)
+              ? collectStatements(file, namedChildren(body), className)
               : [],
           });
         }
@@ -177,8 +187,9 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
+            ...locFromNode(file, clause),
             children: body
-              ? collectStatements(namedChildren(body), className)
+              ? collectStatements(file, namedChildren(body), className)
               : [],
           });
         }
@@ -197,14 +208,16 @@ function collectStatements(
             type: "branch",
             key: text ? `case:${text}` : "case",
             label: text ? `case ${text}` : "case",
-            children: collectStatements(statementsOf(body), className),
+            ...locFromNode(file, cond),
+            children: collectStatements(file, statementsOf(body), className),
           });
         } else {
           steps.push({
             type: "branch",
             key: "else",
             label: "else",
-            children: collectStatements(statementsOf(body), className),
+            ...locFromNode(file, entry),
+            children: collectStatements(file, statementsOf(body), className),
           });
         }
       }
@@ -215,7 +228,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       for (const child of namedChildren(node).slice(1)) walk(child);
       return;
@@ -243,7 +256,7 @@ function handleFunction(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: collectStatements(statementsOf(body), className),
+    steps: collectStatements(file, statementsOf(body), className),
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,
@@ -262,7 +275,7 @@ function handleSecondaryConstructor(
     key: `${className}.constructor`,
     label: `${className}${getParamsLabel(params)}`,
     file,
-    steps: collectStatements(stmts ? namedChildren(stmts) : [], className),
+    steps: collectStatements(file, stmts ? namedChildren(stmts) : [], className),
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,
@@ -282,7 +295,7 @@ function handleInitBlock(
     key: `${className}.init`,
     label: `${className}()`,
     file,
-    steps: collectStatements(stmts ? namedChildren(stmts) : [], className),
+    steps: collectStatements(file, stmts ? namedChildren(stmts) : [], className),
     exported: true,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/lua.ts
+++ b/src/languages/lua.ts
@@ -14,6 +14,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -65,17 +66,18 @@ function statementsOf(body: SyntaxNode | null): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   typeName: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -101,7 +103,8 @@ function collectStatements(
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if ${condText}` : "if",
-        children: collectStatements(statementsOf(thenBlock), typeName),
+        ...locFromNode(file, cond ?? node),
+        children: collectStatements(file, statementsOf(thenBlock), typeName),
       });
 
       for (const clause of kids) {
@@ -113,7 +116,9 @@ function collectStatements(
             type: "branch",
             key: text ? `else-if:${text}` : "else-if",
             label: text ? `elseif ${text}` : "elseif",
+            ...locFromNode(file, elseifCond ?? clause),
             children: collectStatements(
+              file,
               statementsOf(childByType(clause, "block")),
               typeName,
             ),
@@ -124,7 +129,9 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
+            ...locFromNode(file, clause),
             children: collectStatements(
+              file,
               statementsOf(childByType(clause, "block")),
               typeName,
             ),
@@ -138,7 +145,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, typeName);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       for (const child of namedChildren(node).slice(1)) walk(child);
       return;
@@ -205,7 +212,7 @@ function handleFunction(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: collectStatements(statementsOf(body), typeName),
+    steps: collectStatements(file, statementsOf(body), typeName),
     exported: !local,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/ocaml.ts
+++ b/src/languages/ocaml.ts
@@ -6,6 +6,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -71,6 +72,7 @@ function valuePathKey(node: SyntaxNode, moduleName: string | null): string | nul
 }
 
 function collectExpr(
+  file: string,
   node: SyntaxNode | null,
   moduleName: string | null,
 ): CallStep[] {
@@ -78,11 +80,11 @@ function collectExpr(
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (n: SyntaxNode): void => {
@@ -137,7 +139,8 @@ function collectExpr(
           type: "branch",
           key: "try",
           label: "try",
-          children: tryBody ? collectExpr(tryBody, moduleName) : [],
+          ...locFromNode(file, n),
+          children: tryBody ? collectExpr(file, tryBody, moduleName) : [],
         });
       }
       for (const clause of namedChildren(n)) {
@@ -151,7 +154,8 @@ function collectExpr(
           type: "branch",
           key: text ? `${labelKind}:${text}` : labelKind,
           label: text ? `${labelKind} ${text}` : labelKind,
-          children: body ? collectExpr(body, moduleName) : [],
+          ...locFromNode(file, pattern ?? clause),
+          children: body ? collectExpr(file, body, moduleName) : [],
         });
       }
       return;
@@ -170,14 +174,19 @@ function collectExpr(
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if ${condText}` : "if",
+        ...locFromNode(file, cond ?? n),
         children: thenClause
-          ? collectExpr(thenClause.namedChild(0) ?? thenClause, moduleName)
+          ? collectExpr(
+              file,
+              thenClause.namedChild(0) ?? thenClause,
+              moduleName,
+            )
           : [],
       });
       if (elseClause) {
         const elseBody = elseClause.namedChild(0) ?? elseClause;
         if (elseBody.type === "if_expression") {
-          const nested = collectExpr(elseBody, moduleName);
+          const nested = collectExpr(file, elseBody, moduleName);
           for (const s of nested) {
             if (s.type === "branch" && (s.key === "if" || s.key.startsWith("if:"))) {
               steps.push({
@@ -194,7 +203,8 @@ function collectExpr(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectExpr(elseBody, moduleName),
+            ...locFromNode(file, elseClause),
+            children: collectExpr(file, elseBody, moduleName),
           });
         }
       }
@@ -206,7 +216,7 @@ function collectExpr(
       const callee = n.namedChild(0);
       if (callee) {
         const key = valuePathKey(callee, moduleName);
-        if (key) addCall(key, n.startIndex);
+        if (key) addCall(key, n);
       }
       for (const child of namedChildren(n).slice(1)) walk(child);
       return;
@@ -266,7 +276,7 @@ function handleLetBinding(
     key,
     label: `${key}${getParamsLabel(binding)}`,
     file,
-    steps: collectExpr(funBody, moduleName),
+    steps: collectExpr(file, funBody, moduleName),
     exported: true,
     start: binding.startIndex,
     end: binding.endIndex,

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -89,17 +90,18 @@ function condText(node: SyntaxNode | null): string {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -132,8 +134,10 @@ function collectStatements(
         type: "branch",
         key: text ? `if:${text}` : "if",
         label: text ? `if ${text}` : "if",
+        ...locFromNode(file, cond ?? node),
         children: consequent
           ? collectStatements(
+              file,
               consequent.type === "compound_statement"
                 ? namedChildren(consequent)
                 : [consequent],
@@ -158,8 +162,10 @@ function collectStatements(
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",
             label: elifText ? `elseif ${elifText}` : "elseif",
+            ...locFromNode(file, elifCond ?? child),
             children: elifCons
               ? collectStatements(
+                  file,
                   elifCons.type === "compound_statement"
                     ? namedChildren(elifCons)
                     : [elifCons],
@@ -196,8 +202,10 @@ function collectStatements(
               type: "branch",
               key: elifText ? `else-if:${elifText}` : "else-if",
               label: elifText ? `elseif ${elifText}` : "elseif",
+              ...locFromNode(file, elifCond ?? elseClause),
               children: elifCons
                 ? collectStatements(
+                    file,
                     elifCons.type === "compound_statement"
                       ? namedChildren(elifCons)
                       : [elifCons],
@@ -222,8 +230,10 @@ function collectStatements(
                   type: "branch",
                   key: nText ? `else-if:${nText}` : "else-if",
                   label: nText ? `elseif ${nText}` : "elseif",
+                  ...locFromNode(file, nCond ?? nested),
                   children: nBody
                     ? collectStatements(
+                        file,
                         nBody.type === "compound_statement"
                           ? namedChildren(nBody)
                           : [nBody],
@@ -240,7 +250,9 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
+            ...locFromNode(file, elseClause),
             children: collectStatements(
+              file,
               inner.type === "compound_statement"
                 ? namedChildren(inner)
                 : [inner],
@@ -261,8 +273,9 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
+        ...locFromNode(file, node),
         children: body
-          ? collectStatements(namedChildren(body), className)
+          ? collectStatements(file, namedChildren(body), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -279,8 +292,9 @@ function collectStatements(
             type: "branch",
             key: text ? `catch:${text}` : "catch",
             label: text ? `catch ${text}` : "catch",
+            ...locFromNode(file, types ?? clause),
             children: catchBody
-              ? collectStatements(namedChildren(catchBody), className)
+              ? collectStatements(file, namedChildren(catchBody), className)
               : [],
           });
         }
@@ -292,8 +306,9 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
+            ...locFromNode(file, clause),
             children: finallyBody
-              ? collectStatements(namedChildren(finallyBody), className)
+              ? collectStatements(file, namedChildren(finallyBody), className)
               : [],
           });
         }
@@ -305,11 +320,11 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     } else if (node.type === "member_call_expression") {
       const key = memberCallKey(node, className);
-      if (key) addCall(key, node.startIndex);
+      if (key) addCall(key, node);
     } else if (node.type === "scoped_call_expression") {
       // Foo::bar() / self::bar() / static::bar() / parent::bar()
       const method =
@@ -329,12 +344,12 @@ function collectStatements(
         ) {
           addCall(
             className ? `${className}.${method.text}` : method.text,
-            node.startIndex,
+            node,
           );
         } else if (scopeText) {
-          addCall(`${scopeText}.${method.text}`, node.startIndex);
+          addCall(`${scopeText}.${method.text}`, node);
         } else {
-          addCall(method.text, node.startIndex);
+          addCall(method.text, node);
         }
       }
     } else if (node.type === "object_creation_expression") {
@@ -344,7 +359,7 @@ function collectStatements(
         ) ?? null;
       if (typeName) {
         const n = nameText(typeName);
-        if (n) addCall(`new ${n}`, node.startIndex);
+        if (n) addCall(`new ${n}`, node);
       }
     }
 
@@ -368,7 +383,7 @@ function handleFunction(
     key: name,
     label: `${name}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(namedChildren(body), null) : [],
+    steps: body ? collectStatements(file, namedChildren(body), null) : [],
     exported: true,
     start: node.startIndex,
     end: node.endIndex,
@@ -392,7 +407,7 @@ function handleMethod(
     key,
     label: `${label}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(namedChildren(body), className) : [],
+    steps: body ? collectStatements(file, namedChildren(body), className) : [],
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -6,6 +6,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -95,25 +96,27 @@ function calleeKey(node: SyntaxNode, className: string | null): string | null {
 }
 
 function collectBlock(
+  file: string,
   block: SyntaxNode | null,
   className: string | null,
 ): CallStep[] {
   if (!block) return [];
-  return collectStatements(namedChildren(block), className);
+  return collectStatements(file, namedChildren(block), className);
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -140,7 +143,8 @@ function collectStatements(
         type: "branch",
         key: cond ? `if:${cond}` : "if",
         label: cond ? `if ${cond}` : "if",
-        children: collectBlock(childByType(node, "block"), className),
+        ...locFromNode(file, condNode ?? node),
+        children: collectBlock(file, childByType(node, "block"), className),
       });
 
       for (const clause of namedChildren(node)) {
@@ -152,7 +156,8 @@ function collectStatements(
             type: "branch",
             key: text ? `else-if:${text}` : "else-if",
             label: text ? `elif ${text}` : "elif",
-            children: collectBlock(childByType(clause, "block"), className),
+            ...locFromNode(file, elifCond ?? clause),
+            children: collectBlock(file, childByType(clause, "block"), className),
           });
         }
         if (clause.type === "else_clause") {
@@ -160,7 +165,8 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectBlock(childByType(clause, "block"), className),
+            ...locFromNode(file, clause),
+            children: collectBlock(file, childByType(clause, "block"), className),
           });
         }
       }
@@ -186,7 +192,8 @@ function collectStatements(
           type: "branch",
           key: text ? `case:${text}` : "case",
           label,
-          children: collectBlock(childByType(clause, "block"), className),
+          ...locFromNode(file, pattern ?? clause),
+          children: collectBlock(file, childByType(clause, "block"), className),
         });
       }
       return;
@@ -198,7 +205,8 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
-        children: collectBlock(tryBlock, className),
+        ...locFromNode(file, node),
+        children: collectBlock(file, tryBlock, className),
       });
       for (const clause of namedChildren(node)) {
         if (clause.type === "except_clause") {
@@ -211,7 +219,8 @@ function collectStatements(
             type: "branch",
             key: text ? `except:${text}` : "except",
             label: text ? `except ${text}` : "except",
-            children: collectBlock(childByType(clause, "block"), className),
+            ...locFromNode(file, handlerType ?? clause),
+            children: collectBlock(file, childByType(clause, "block"), className),
           });
         }
         if (clause.type === "else_clause") {
@@ -219,7 +228,8 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectBlock(childByType(clause, "block"), className),
+            ...locFromNode(file, clause),
+            children: collectBlock(file, childByType(clause, "block"), className),
           });
         }
         if (clause.type === "finally_clause") {
@@ -227,7 +237,8 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
-            children: collectBlock(childByType(clause, "block"), className),
+            ...locFromNode(file, clause),
+            children: collectBlock(file, childByType(clause, "block"), className),
           });
         }
       }
@@ -238,7 +249,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       // Still walk arguments for nested calls, but not into nested lambdas
       for (const child of namedChildren(node).slice(1)) walk(child);
@@ -275,9 +286,9 @@ function pushFunction(
     file,
     steps:
       body && body.type === "block"
-        ? collectBlock(body, className)
+        ? collectBlock(file, body, className)
         : body
-          ? collectStatements([body], className)
+          ? collectStatements(file, [body], className)
           : [],
     exported,
     start: node.startIndex,

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -8,6 +8,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -104,28 +105,30 @@ function bareCallKey(
 }
 
 function collectBody(
+  file: string,
   body: SyntaxNode | null,
   className: string | null,
 ): CallStep[] {
   if (!body) return [];
   if (body.type === "body_statement" || body.type === "then" || body.type === "else") {
-    return collectStatements(namedChildren(body), className);
+    return collectStatements(file, namedChildren(body), className);
   }
-  return collectStatements([body], className);
+  return collectStatements(file, [body], className);
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode, asStatement: boolean): void => {
@@ -158,7 +161,8 @@ function collectStatements(
         type: "branch",
         key: condText ? `${kind}:${condText}` : kind,
         label: condText ? `${kind} ${condText}` : kind,
-        children: collectBody(thenNode, className),
+        ...locFromNode(file, cond ?? node),
+        children: collectBody(file, thenNode, className),
       });
 
       for (const clause of kids) {
@@ -172,7 +176,8 @@ function collectStatements(
             type: "branch",
             key: text ? `else-if:${text}` : "else-if",
             label: text ? `elsif ${text}` : "elsif",
-            children: collectBody(childByType(clause, "then"), className),
+            ...locFromNode(file, elsifCond ?? clause),
+            children: collectBody(file, childByType(clause, "then"), className),
           });
           // nested else under elsif
           const nestedElse = childByType(clause, "else");
@@ -181,7 +186,8 @@ function collectStatements(
               type: "branch",
               key: "else",
               label: "else",
-              children: collectBody(nestedElse, className),
+              ...locFromNode(file, nestedElse),
+              children: collectBody(file, nestedElse, className),
             });
           }
         }
@@ -190,7 +196,8 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectBody(clause, className),
+            ...locFromNode(file, clause),
+            children: collectBody(file, clause, className),
           });
         }
       }
@@ -209,7 +216,8 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "begin",
-        children: collectStatements(bodyStmts, className),
+        ...locFromNode(file, node),
+        children: collectStatements(file, bodyStmts, className),
       });
       for (const clause of namedChildren(node)) {
         if (clause.type === "rescue") {
@@ -220,9 +228,11 @@ function collectStatements(
             type: "branch",
             key: text ? `rescue:${text}` : "rescue",
             label: text ? `rescue ${text}` : "rescue",
+            ...locFromNode(file, exceptions ?? clause),
             children: thenNode
-              ? collectBody(thenNode, className)
+              ? collectBody(file, thenNode, className)
               : collectStatements(
+                  file,
                   namedChildren(clause).filter(
                     (c) => c.type !== "exceptions" && c.type !== "exception_variable",
                   ),
@@ -235,7 +245,8 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectBody(clause, className),
+            ...locFromNode(file, clause),
+            children: collectBody(file, clause, className),
           });
         }
         if (clause.type === "ensure") {
@@ -243,7 +254,8 @@ function collectStatements(
             type: "branch",
             key: "ensure",
             label: "ensure",
-            children: collectStatements(namedChildren(clause), className),
+            ...locFromNode(file, clause),
+            children: collectStatements(file, namedChildren(clause), className),
           });
         }
       }
@@ -262,7 +274,8 @@ function collectStatements(
             type: "branch",
             key: text ? `when:${text}` : "when",
             label: text ? `when ${text}` : "when",
-            children: collectBody(childByType(clause, "then"), className),
+            ...locFromNode(file, pattern ?? clause),
+            children: collectBody(file, childByType(clause, "then"), className),
           });
         }
         if (clause.type === "else") {
@@ -270,7 +283,8 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectBody(clause, className),
+            ...locFromNode(file, clause),
+            children: collectBody(file, clause, className),
           });
         }
       }
@@ -303,7 +317,7 @@ function collectStatements(
         (asStatement || hasArgs || !isReceiverCall)
       ) {
         const key = callKey(node, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       // Nested invocations inside arguments (not bare attr reads)
       const args = childByType(node, "argument_list");
@@ -323,7 +337,7 @@ function collectStatements(
           // Prefer free name for top-level helpers assigned into locals
           if (key) {
             // If className set, bareCallKey prefixes — for assignment RHS use free name
-            addCall(rhs.text, rhs.startIndex);
+            addCall(rhs.text, rhs);
           }
         } else {
           walk(rhs, false);
@@ -335,7 +349,7 @@ function collectStatements(
     // Statement-level bare identifier → method call
     if (node.type === "identifier" && asStatement) {
       const key = bareCallKey(node, className);
-      if (key) addCall(key, node.startIndex);
+      if (key) addCall(key, node);
       return;
     }
 
@@ -371,7 +385,7 @@ function handleMethod(
     key,
     label: `${labelBase}${getParamsLabel(params)}`,
     file,
-    steps: collectBody(body, className),
+    steps: collectBody(file, body, className),
     exported: !name.startsWith("_"),
     start: node.startIndex,
     end: node.endIndex,
@@ -403,7 +417,7 @@ function handleSingletonMethod(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: collectBody(body, className),
+    steps: collectBody(file, body, className),
     exported: !name.startsWith("_"),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -97,17 +98,18 @@ function statementsOf(node: SyntaxNode): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   typeName: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const pushIfChain = (node: SyntaxNode, asElseIf: boolean): void => {
@@ -124,8 +126,9 @@ function collectStatements(
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,
       label: condText ? `${labelKind} ${condText}` : labelKind,
+      ...locFromNode(file, cond ?? node),
       children: thenBlock
-        ? collectStatements(statementsOf(thenBlock), typeName)
+        ? collectStatements(file, statementsOf(thenBlock), typeName)
         : [],
     });
 
@@ -142,7 +145,8 @@ function collectStatements(
       type: "branch",
       key: "else",
       label: "else",
-      children: collectStatements(statementsOf(elseInner), typeName),
+      ...locFromNode(file, elseClause),
+      children: collectStatements(file, statementsOf(elseInner), typeName),
     });
   };
 
@@ -186,8 +190,9 @@ function collectStatements(
           type: "branch",
           key: text ? `case:${text}` : "case",
           label: text ? `case ${text}` : "case",
+          ...locFromNode(file, pattern ?? arm),
           children: body
-            ? collectStatements(statementsOf(body), typeName)
+            ? collectStatements(file, statementsOf(body), typeName)
             : [],
         });
       }
@@ -198,7 +203,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, typeName);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     }
 
@@ -233,7 +238,7 @@ function handleFunctionItem(
     key,
     label: `${labelBase}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), typeName) : [],
+    steps: body ? collectStatements(file, statementsOf(body), typeName) : [],
     exported,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/scala.ts
+++ b/src/languages/scala.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -72,17 +73,18 @@ function statementsOf(body: SyntaxNode | null): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   typeName: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const pushIfChain = (node: SyntaxNode, asElseIf: boolean): void => {
@@ -107,7 +109,12 @@ function collectStatements(
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,
       label: condText ? `${labelKind} (${condText})` : labelKind,
-      children: collectStatements(statementsOf(blocks[0] ?? null), typeName),
+      ...locFromNode(file, condInner ?? node),
+      children: collectStatements(
+        file,
+        statementsOf(blocks[0] ?? null),
+        typeName,
+      ),
     });
 
     if (nestedIf) {
@@ -120,7 +127,8 @@ function collectStatements(
         type: "branch",
         key: "else",
         label: "else",
-        children: collectStatements(statementsOf(blocks[1]), typeName),
+        ...locFromNode(file, blocks[1]),
+        children: collectStatements(file, statementsOf(blocks[1]), typeName),
       });
     }
   };
@@ -147,7 +155,8 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
-        children: collectStatements(statementsOf(tryBlock), typeName),
+        ...locFromNode(file, node),
+        children: collectStatements(file, statementsOf(tryBlock), typeName),
       });
       for (const clause of namedChildren(node)) {
         if (clause.type === "catch_clause") {
@@ -158,7 +167,8 @@ function collectStatements(
               type: "branch",
               key: "catch",
               label: "catch",
-              children: collectStatements(namedChildren(clause), typeName),
+              ...locFromNode(file, clause),
+              children: collectStatements(file, namedChildren(clause), typeName),
             });
           } else {
             for (const c of cases) {
@@ -176,7 +186,8 @@ function collectStatements(
                 type: "branch",
                 key: text ? `catch:${text}` : "catch",
                 label: text ? `catch ${text}` : "catch",
-                children: collectStatements(bodyNodes, typeName),
+                ...locFromNode(file, pattern ?? c),
+                children: collectStatements(file, bodyNodes, typeName),
               });
             }
           }
@@ -188,7 +199,8 @@ function collectStatements(
             type: "branch",
             key: "finally",
             label: "finally",
-            children: collectStatements(statementsOf(body), typeName),
+            ...locFromNode(file, clause),
+            children: collectStatements(file, statementsOf(body), typeName),
           });
         }
       }
@@ -207,7 +219,8 @@ function collectStatements(
           type: "branch",
           key: text ? `case:${text}` : "case",
           label: text ? `case ${text}` : "case",
-          children: collectStatements(bodyNodes, typeName),
+          ...locFromNode(file, pattern ?? clause),
+          children: collectStatements(file, bodyNodes, typeName),
         });
       }
       return;
@@ -217,7 +230,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, typeName);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       for (const child of namedChildren(node).slice(1)) walk(child);
       return;
@@ -226,7 +239,7 @@ function collectStatements(
     if (node.type === "instance_expression") {
       // new Foo(args)
       const typeId = childByType(node, "type_identifier");
-      if (typeId) addCall(`new ${typeId.text}`, node.startIndex);
+      if (typeId) addCall(`new ${typeId.text}`, node);
       for (const child of namedChildren(node)) walk(child);
       return;
     }
@@ -262,7 +275,7 @@ function handleFunction(
 
   const key = typeName ? `${typeName}.${name}` : name;
   const exported = !isPrivate(node);
-  const steps = collectStatements(statementsOf(body), typeName);
+  const steps = collectStatements(file, statementsOf(body), typeName);
   functions.push({
     key,
     label: `${key}${getParamsLabel(params)}`,

--- a/src/languages/solidity.ts
+++ b/src/languages/solidity.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -82,17 +83,18 @@ function unwrapStatement(stmt: SyntaxNode): SyntaxNode {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   contractName: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -125,13 +127,14 @@ function collectStatements(
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if ${condText}` : "if",
+        ...locFromNode(file, cond ?? node),
         children: thenNode
-          ? collectStatements(statementsOf(thenNode), contractName)
+          ? collectStatements(file, statementsOf(thenNode), contractName)
           : [],
       });
       if (elseNode) {
         if (elseNode.type === "if_statement") {
-          const nested = collectStatements([elseNode], contractName);
+          const nested = collectStatements(file, [elseNode], contractName);
           for (const s of nested) {
             if (s.type === "branch" && (s.key === "if" || s.key.startsWith("if:"))) {
               steps.push({
@@ -148,7 +151,12 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectStatements(statementsOf(elseNode), contractName),
+            ...locFromNode(file, elseNode),
+            children: collectStatements(
+              file,
+              statementsOf(elseNode),
+              contractName,
+            ),
           });
         }
       }
@@ -167,7 +175,7 @@ function collectStatements(
       }
       if (target) {
         const key = calleeKey(target, contractName);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       for (const child of namedChildren(node).slice(1)) walk(child);
       return;
@@ -201,7 +209,9 @@ function handleFunction(
     key,
     label: `${key}${getParamsLabel(node)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), contractName) : [],
+    steps: body
+      ? collectStatements(file, statementsOf(body), contractName)
+      : [],
     exported: visibility === "private" || visibility === "internal" ? false : exported,
     start: node.startIndex,
     end: node.endIndex,
@@ -219,7 +229,9 @@ function handleConstructor(
     key: `${contractName}.constructor`,
     label: `new ${contractName}${getParamsLabel(node)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), contractName) : [],
+    steps: body
+      ? collectStatements(file, statementsOf(body), contractName)
+      : [],
     exported: true,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -75,17 +76,18 @@ function statementsOf(body: SyntaxNode | null): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const pushIfChain = (node: SyntaxNode, asElseIf: boolean): void => {
@@ -107,7 +109,9 @@ function collectStatements(
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,
       label: condText ? `${labelKind} ${condText}` : labelKind,
+      ...locFromNode(file, cond ?? node),
       children: collectStatements(
+        file,
         statementsOf(stmtBlocks[0] ?? null),
         className,
       ),
@@ -123,7 +127,12 @@ function collectStatements(
         type: "branch",
         key: "else",
         label: "else",
-        children: collectStatements(statementsOf(stmtBlocks[1]), className),
+        ...locFromNode(file, stmtBlocks[1]),
+        children: collectStatements(
+          file,
+          statementsOf(stmtBlocks[1]),
+          className,
+        ),
       });
     }
   };
@@ -149,8 +158,9 @@ function collectStatements(
         type: "branch",
         key: "do",
         label: "do",
+        ...locFromNode(file, node),
         children: doBody
-          ? collectStatements(namedChildren(doBody), className)
+          ? collectStatements(file, namedChildren(doBody), className)
           : [],
       });
       for (const clause of namedChildren(node)) {
@@ -160,8 +170,9 @@ function collectStatements(
             type: "branch",
             key: "catch",
             label: "catch",
+            ...locFromNode(file, clause),
             children: body
-              ? collectStatements(namedChildren(body), className)
+              ? collectStatements(file, namedChildren(body), className)
               : [],
           });
         }
@@ -182,8 +193,9 @@ function collectStatements(
             type: "branch",
             key: "default",
             label: "default",
+            ...locFromNode(file, entry),
             children: body
-              ? collectStatements(namedChildren(body), className)
+              ? collectStatements(file, namedChildren(body), className)
               : [],
           });
         } else {
@@ -192,8 +204,9 @@ function collectStatements(
             type: "branch",
             key: text ? `case:${text}` : "case",
             label: text ? `case ${text}` : "case",
+            ...locFromNode(file, pattern),
             children: body
-              ? collectStatements(namedChildren(body), className)
+              ? collectStatements(file, namedChildren(body), className)
               : [],
           });
         }
@@ -205,7 +218,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       for (const child of namedChildren(node).slice(1)) walk(child);
       return;
@@ -238,7 +251,7 @@ function handleFunction(
     key,
     label: `${key}${getParamsLabel(node)}`,
     file,
-    steps: collectStatements(statementsOf(body), className),
+    steps: collectStatements(file, statementsOf(body), className),
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,
@@ -256,7 +269,7 @@ function handleInit(
     key: `${className}.init`,
     label: `${className}${getParamsLabel(node)}`,
     file,
-    steps: collectStatements(statementsOf(body), className),
+    steps: collectStatements(file, statementsOf(body), className),
     exported: !isPrivate(node),
     start: node.startIndex,
     end: node.endIndex,

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -1,5 +1,5 @@
 import type Parser from "tree-sitter";
-import type { FunctionInfo } from "../types.js";
+import type { FunctionInfo, SourceLoc } from "../types.js";
 
 export type SyntaxNode = Parser.SyntaxNode;
 export type Tree = Parser.Tree;
@@ -31,4 +31,14 @@ export function childByType(node: SyntaxNode, type: string): SyntaxNode | null {
 
 export function collapseWs(text: string): string {
   return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Call-site / branch span for a syntax node.
+ * Uses tree-sitter 0-based rows → 1-based display lines.
+ */
+export function locFromNode(file: string, node: SyntaxNode): SourceLoc {
+  const line = node.startPosition.row + 1;
+  const endLine = node.endPosition.row + 1;
+  return endLine > line ? { file, line, endLine } : { file, line };
 }

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -5,6 +5,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -135,17 +136,18 @@ function statementsOf(node: SyntaxNode): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   className: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seenCalls = new Set<string>();
 
-  const addCall = (key: string, startIndex: number) => {
-    const mark = `${key}:${startIndex}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seenCalls.has(mark)) return;
     seenCalls.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walkExpr = (node: SyntaxNode): void => {
@@ -173,8 +175,9 @@ function collectStatements(
         type: "branch",
         key: branchKey("if", cond),
         label: test ? `if (${condText(test)})` : "if",
+        ...locFromNode(file, test ?? node),
         children: consequent
-          ? collectStatements(statementsOf(consequent), className)
+          ? collectStatements(file, statementsOf(consequent), className)
           : [],
       });
 
@@ -198,8 +201,9 @@ function collectStatements(
             type: "branch",
             key: branchKey("else-if", elseCond),
             label: elseTest ? `else if (${condText(elseTest)})` : "else if",
+            ...locFromNode(file, elseTest ?? current),
             children: elseConsequent
-              ? collectStatements(statementsOf(elseConsequent), className)
+              ? collectStatements(file, statementsOf(elseConsequent), className)
               : [],
           });
           current = childByType(inner, "else_clause");
@@ -210,7 +214,8 @@ function collectStatements(
           type: "branch",
           key: branchKey("else", ""),
           label: "else",
-          children: collectStatements(statementsOf(inner), className),
+          ...locFromNode(file, current),
+          children: collectStatements(file, statementsOf(inner), className),
         });
         break;
       }
@@ -221,14 +226,14 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
     } else if (type === "new_expression") {
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, null);
         if (key) {
-          addCall(key.startsWith("new ") ? key : `new ${key}`, node.startIndex);
+          addCall(key.startsWith("new ") ? key : `new ${key}`, node);
         }
       }
     } else if (type === "jsx_element") {
@@ -244,21 +249,26 @@ function collectStatements(
             attr.type === "jsx_attribute" ||
             attr.type === "jsx_expression"
           ) {
-            fromAttrs.push(...collectStatements([attr], className));
+            fromAttrs.push(...collectStatements(file, [attr], className));
           }
         }
       }
       const nested = [
         ...fromAttrs,
-        ...collectStatements(childNodes, className),
+        ...collectStatements(file, childNodes, className),
       ];
       if (opening) {
         const key = jsxCalleeKey(opening);
         if (key) {
           if (nested.length > 0) {
-            steps.push({ type: "call", key, children: nested });
+            steps.push({
+              type: "call",
+              key,
+              ...locFromNode(file, opening),
+              children: nested,
+            });
           } else {
-            addCall(key, opening.startIndex);
+            addCall(key, opening);
           }
           return;
         }
@@ -269,13 +279,18 @@ function collectStatements(
       const attrNodes = namedChildren(node).filter(
         (c) => c.type === "jsx_attribute" || c.type === "jsx_expression",
       );
-      const nested = collectStatements(attrNodes, className);
+      const nested = collectStatements(file, attrNodes, className);
       const key = jsxCalleeKey(node);
       if (key) {
         if (nested.length > 0) {
-          steps.push({ type: "call", key, children: nested });
+          steps.push({
+            type: "call",
+            key,
+            ...locFromNode(file, node),
+            children: nested,
+          });
         } else {
-          addCall(key, node.startIndex);
+          addCall(key, node);
         }
       } else {
         for (const step of nested) steps.push(step);
@@ -296,14 +311,15 @@ function collectStatements(
 }
 
 function collectStepsFromBody(
+  file: string,
   body: SyntaxNode | null,
   className: string | null,
 ): CallStep[] {
   if (!body) return [];
   if (body.type === "statement_block") {
-    return collectStatements(namedChildren(body), className);
+    return collectStatements(file, namedChildren(body), className);
   }
-  return collectStatements([body], className);
+  return collectStatements(file, [body], className);
 }
 
 function functionFromParts(
@@ -322,7 +338,7 @@ function functionFromParts(
     key,
     label: `${label}${paramsLabel}`,
     file,
-    steps: collectStepsFromBody(body, className),
+    steps: collectStepsFromBody(file, body, className),
     exported,
     start,
     end,

--- a/src/languages/zig.ts
+++ b/src/languages/zig.ts
@@ -6,6 +6,7 @@ import type { CallStep, FunctionInfo } from "../types.js";
 import {
   childByType,
   collapseWs,
+  locFromNode,
   namedChildren,
   type LanguageExtractor,
   type SyntaxNode,
@@ -57,17 +58,18 @@ function statementsOf(block: SyntaxNode | null): SyntaxNode[] {
 }
 
 function collectStatements(
+  file: string,
   statements: SyntaxNode[],
   typeName: string | null,
 ): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, start: number) => {
-    const mark = `${key}:${start}`;
+  const addCall = (key: string, node: SyntaxNode) => {
+    const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key });
+    steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
   const walk = (node: SyntaxNode): void => {
@@ -101,7 +103,8 @@ function collectStatements(
         type: "branch",
         key: condText ? `if:${condText}` : "if",
         label: condText ? `if ${condText}` : "if",
-        children: collectStatements(statementsOf(thenBlock), typeName),
+        ...locFromNode(file, cond ?? node),
+        children: collectStatements(file, statementsOf(thenBlock), typeName),
       });
       if (elseClause) {
         // else_clause → block | labeled_statement → block | if_statement
@@ -114,7 +117,7 @@ function collectStatements(
           null;
         if (elseBody?.type === "if_statement") {
           // else if — flatten by walking as nested if into else-if style
-          const nested = collectStatements([elseBody], typeName);
+          const nested = collectStatements(file, [elseBody], typeName);
           for (const s of nested) {
             if (s.type === "branch" && s.key.startsWith("if:")) {
               steps.push({
@@ -135,14 +138,16 @@ function collectStatements(
             type: "branch",
             key: "else",
             label: "else",
-            children: collectStatements(statementsOf(blk), typeName),
+            ...locFromNode(file, elseClause),
+            children: collectStatements(file, statementsOf(blk), typeName),
           });
         } else {
           steps.push({
             type: "branch",
             key: "else",
             label: "else",
-            children: collectStatements(statementsOf(elseBody), typeName),
+            ...locFromNode(file, elseClause),
+            children: collectStatements(file, statementsOf(elseBody), typeName),
           });
         }
       }
@@ -154,7 +159,8 @@ function collectStatements(
         type: "branch",
         key: "try",
         label: "try",
-        children: collectStatements(namedChildren(node), typeName),
+        ...locFromNode(file, node),
+        children: collectStatements(file, namedChildren(node), typeName),
       });
       return;
     }
@@ -164,7 +170,8 @@ function collectStatements(
         type: "branch",
         key: "defer",
         label: "defer",
-        children: collectStatements(namedChildren(node), typeName),
+        ...locFromNode(file, node),
+        children: collectStatements(file, namedChildren(node), typeName),
       });
       return;
     }
@@ -189,8 +196,9 @@ function collectStatements(
           type: "branch",
           key: isElse ? "else" : text ? `case:${text}` : "case",
           label: isElse ? "else" : text ? `case ${text}` : "case",
+          ...locFromNode(file, pattern ?? clause),
           children: bodyNode
-            ? collectStatements([bodyNode], typeName)
+            ? collectStatements(file, [bodyNode], typeName)
             : [],
         });
       }
@@ -201,7 +209,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, typeName);
-        if (key) addCall(key, node.startIndex);
+        if (key) addCall(key, node);
       }
       for (const child of namedChildren(node).slice(1)) walk(child);
       return;
@@ -229,7 +237,7 @@ function handleFunction(
     key,
     label: `${key}${getParamsLabel(params)}`,
     file,
-    steps: body ? collectStatements(statementsOf(body), typeName) : [],
+    steps: body ? collectStatements(file, statementsOf(body), typeName) : [],
     exported: true,
     start: node.startIndex,
     end: node.endIndex,

--- a/src/loc.ts
+++ b/src/loc.ts
@@ -1,0 +1,45 @@
+import type { SourceLoc } from "./types.js";
+
+/** Pick optional loc fields for spreading onto a node/step. */
+export function pickLoc(
+  loc:
+    | { file?: string; line?: number; endLine?: number }
+    | null
+    | undefined,
+): Partial<SourceLoc> {
+  if (!loc?.file || loc.line == null) return {};
+  if (loc.endLine != null && loc.endLine !== loc.line) {
+    return { file: loc.file, line: loc.line, endLine: loc.endLine };
+  }
+  return { file: loc.file, line: loc.line };
+}
+
+/** Format as `file:line` or `file:line-line`. */
+export function formatSourceLoc(loc: SourceLoc): string {
+  const range =
+    loc.endLine != null && loc.endLine !== loc.line
+      ? `${loc.line}-${loc.endLine}`
+      : String(loc.line);
+  return `${loc.file}:${range}`;
+}
+
+/**
+ * Convert byte offsets in `source` to 1-based line numbers.
+ * `end` is exclusive (tree-sitter endIndex).
+ */
+export function linesFromOffsets(
+  source: string,
+  start: number,
+  end: number,
+): { line: number; endLine?: number } {
+  let line = 1;
+  for (let i = 0; i < start && i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) line += 1;
+  }
+  let endLine = line;
+  const last = Math.max(start, end - 1);
+  for (let i = start; i < last && i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) endLine += 1;
+  }
+  return endLine > line ? { line, endLine } : { line };
+}

--- a/src/reach.ts
+++ b/src/reach.ts
@@ -26,6 +26,9 @@ export function pathToTree(nodes: CallNode[]): CallNode {
     key: head!.key,
     label: head!.label,
     ...(head!.kind ? { kind: head!.kind } : {}),
+    ...(head!.file ? { file: head!.file } : {}),
+    ...(head!.line != null ? { line: head!.line } : {}),
+    ...(head!.endLine != null ? { endLine: head!.endLine } : {}),
     children: rest.length > 0 ? [pathToTree(rest)] : [],
   };
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -29,7 +29,7 @@ export interface RenderOptions {
   color?: boolean;
   /**
    * Append `file:line` (or `file:line-line`) after each label.
-   * Default: true.
+   * Default: false.
    */
   locs?: boolean;
 }
@@ -50,7 +50,7 @@ function renderAsciiTree(
   withStatus: boolean,
 ): string {
   const useColor = options.color !== false;
-  const showLocs = options.locs !== false;
+  const showLocs = options.locs === true;
 
   const paintStatus = (status: DiffStatus, text: string): string =>
     useColor ? paint(status, text) : text;

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,6 @@
 import pc from "picocolors";
-import type { CallNode, DiffNode, DiffStatus } from "./types.js";
+import { formatSourceLoc, pickLoc } from "./loc.js";
+import type { CallNode, DiffNode, DiffStatus, SourceLoc } from "./types.js";
 
 function paint(status: DiffStatus, text: string): string {
   switch (status) {
@@ -26,6 +27,11 @@ function prefix(status: DiffStatus): string {
 export interface RenderOptions {
   /** When false, skip ANSI colors (useful for tests). Default: true */
   color?: boolean;
+  /**
+   * Append `file:line` (or `file:line-line`) after each label.
+   * Default: true.
+   */
+  locs?: boolean;
 }
 
 type TreeLike = {
@@ -33,6 +39,9 @@ type TreeLike = {
   kind?: CallNode["kind"];
   children: TreeLike[];
   status?: DiffStatus;
+  file?: string;
+  line?: number;
+  endLine?: number;
 };
 
 function renderAsciiTree(
@@ -41,6 +50,7 @@ function renderAsciiTree(
   withStatus: boolean,
 ): string {
   const useColor = options.color !== false;
+  const showLocs = options.locs !== false;
 
   const paintStatus = (status: DiffStatus, text: string): string =>
     useColor ? paint(status, text) : text;
@@ -59,6 +69,14 @@ function renderAsciiTree(
     return prefix(status);
   };
 
+  const locSuffix = (node: TreeLike): string => {
+    if (!showLocs) return "";
+    const loc = pickLoc(node);
+    if (!loc.file || loc.line == null) return "";
+    const text = `  ${formatSourceLoc(loc as SourceLoc)}`;
+    return useColor ? pc.dim(text) : text;
+  };
+
   const lines: string[] = [];
 
   const walk = (
@@ -71,9 +89,10 @@ function renderAsciiTree(
     const label = withStatus
       ? paintStatus(node.status ?? "same", node.label)
       : node.label;
+    const suffix = locSuffix(node);
     const line = withStatus
-      ? `${statusPrefix(node.status ?? "same")} ${indent}${branch}${label}`
-      : `${indent}${branch}${label}`;
+      ? `${statusPrefix(node.status ?? "same")} ${indent}${branch}${label}${suffix}`
+      : `${indent}${branch}${label}${suffix}`;
     lines.push(line);
 
     // Conditional arms omit the continuing │ rail — they are alternate paths,

--- a/src/run.ts
+++ b/src/run.ts
@@ -31,7 +31,7 @@ export type DiffRunOptions = {
   maxDepth?: number;
   /** When false, skip ANSI colors in ascii output. Default: true */
   color?: boolean;
-  /** When false, omit file:line suffixes in ascii. Default: true */
+  /** When true, append file:line suffixes in ascii. Default: false */
   locs?: boolean;
 };
 
@@ -121,7 +121,7 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   const maxDepth = options.maxDepth ?? 12;
   const entriesOpt = options.entries ?? [];
   const color = options.color !== false;
-  const locs = options.locs !== false;
+  const locs = options.locs === true;
 
   assertGitRepo(cwd);
 
@@ -203,7 +203,7 @@ export function runTree(options: TreeRunOptions): TreeResult {
   const cwd = options.cwd ?? process.cwd();
   const maxDepth = options.maxDepth ?? 12;
   const color = options.color !== false;
-  const locs = options.locs !== false;
+  const locs = options.locs === true;
 
   assertGitRepo(cwd);
 
@@ -246,7 +246,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const cwd = options.cwd ?? process.cwd();
   const maxDepth = options.maxDepth ?? 12;
   const color = options.color !== false;
-  const locs = options.locs !== false;
+  const locs = options.locs === true;
 
   assertGitRepo(cwd);
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -31,6 +31,8 @@ export type DiffRunOptions = {
   maxDepth?: number;
   /** When false, skip ANSI colors in ascii output. Default: true */
   color?: boolean;
+  /** When false, omit file:line suffixes in ascii. Default: true */
+  locs?: boolean;
 };
 
 export type TreeRunOptions = {
@@ -40,6 +42,7 @@ export type TreeRunOptions = {
   cwd?: string;
   maxDepth?: number;
   color?: boolean;
+  locs?: boolean;
 };
 
 export type ReachRunOptions = {
@@ -52,6 +55,7 @@ export type ReachRunOptions = {
   cwd?: string;
   maxDepth?: number;
   color?: boolean;
+  locs?: boolean;
 };
 
 function loadIndex(
@@ -91,6 +95,9 @@ function serializeCallNode(node: CallNode): CallNode {
     key: node.key,
     label: node.label,
     ...(node.kind ? { kind: node.kind } : {}),
+    ...(node.file ? { file: node.file } : {}),
+    ...(node.line != null ? { line: node.line } : {}),
+    ...(node.endLine != null ? { endLine: node.endLine } : {}),
     children: node.children.map(serializeCallNode),
   };
 }
@@ -101,6 +108,9 @@ function serializeDiffNode(node: DiffNode): DiffNode {
     label: node.label,
     status: node.status,
     ...(node.kind ? { kind: node.kind } : {}),
+    ...(node.file ? { file: node.file } : {}),
+    ...(node.line != null ? { line: node.line } : {}),
+    ...(node.endLine != null ? { endLine: node.endLine } : {}),
     children: node.children.map(serializeDiffNode),
   };
 }
@@ -111,6 +121,7 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   const maxDepth = options.maxDepth ?? 12;
   const entriesOpt = options.entries ?? [];
   const color = options.color !== false;
+  const locs = options.locs !== false;
 
   assertGitRepo(cwd);
 
@@ -156,10 +167,10 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   for (const entry of entries) {
     const diff = diffEntry(entry, before, after, maxDepth);
     if (!diff) continue;
-    const ascii = renderDiff(diff, { color });
+    const ascii = renderDiff(diff, { color, locs });
     trees.push({
       entry,
-      ascii: renderDiff(diff, { color: false }),
+      ascii: renderDiff(diff, { color: false, locs }),
       tree: serializeDiffNode(diff),
     });
     if (asciiParts.length > 2) asciiParts.push("");
@@ -192,6 +203,7 @@ export function runTree(options: TreeRunOptions): TreeResult {
   const cwd = options.cwd ?? process.cwd();
   const maxDepth = options.maxDepth ?? 12;
   const color = options.color !== false;
+  const locs = options.locs !== false;
 
   assertGitRepo(cwd);
 
@@ -211,10 +223,10 @@ export function runTree(options: TreeRunOptions): TreeResult {
 
   for (const entry of entries) {
     const tree = buildCallTree(entry, index, maxDepth);
-    const ascii = renderTree(tree, { color });
+    const ascii = renderTree(tree, { color, locs });
     trees.push({
       entry,
-      ascii: renderTree(tree, { color: false }),
+      ascii: renderTree(tree, { color: false, locs }),
       tree: serializeCallNode(tree),
     });
     if (asciiParts.length > 2) asciiParts.push("");
@@ -234,6 +246,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const cwd = options.cwd ?? process.cwd();
   const maxDepth = options.maxDepth ?? 12;
   const color = options.color !== false;
+  const locs = options.locs !== false;
 
   assertGitRepo(cwd);
 
@@ -257,7 +270,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
     const found = findReachPaths(entry, targetKey, index, maxDepth);
     for (const path of found) {
       pathResults.push({
-        ascii: renderTree(path, { color: false }),
+        ascii: renderTree(path, { color: false, locs }),
         tree: serializeCallNode(path),
       });
     }
@@ -287,7 +300,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
     if (pathResults.length > 1) {
       asciiParts.push(`# path ${i + 1}`);
     }
-    asciiParts.push(renderTree(path.tree, { color }));
+    asciiParts.push(renderTree(path.tree, { color, locs }));
   }
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,14 @@
 export type CallNodeKind = "call" | "branch";
 
+/** Source location as shown in editors: `file:line` or `file:line-line`. */
+export interface SourceLoc {
+  file: string;
+  /** 1-based start line */
+  line: number;
+  /** 1-based end line when the span covers multiple lines */
+  endLine?: number;
+}
+
 export interface CallNode {
   /** Stable identity used for matching across versions, e.g. "PiService.createAgentSession" */
   key: string;
@@ -7,6 +16,13 @@ export interface CallNode {
   label: string;
   /** Branches omit the continuing │ rail so arms read as alternate paths */
   kind?: CallNodeKind;
+  /**
+   * Root: definition location. Children: call-site (or branch keyword) in the parent.
+   * Matching/diff keys ignore these fields.
+   */
+  file?: string;
+  line?: number;
+  endLine?: number;
   children: CallNode[];
 }
 
@@ -15,6 +31,10 @@ export type CallStep =
   | {
       type: "call";
       key: string;
+      /** Call-expression span in the caller file. */
+      file?: string;
+      line?: number;
+      endLine?: number;
       /** Inline children (e.g. JSX component children at the call site). */
       children?: CallStep[];
     }
@@ -22,6 +42,10 @@ export type CallStep =
       type: "branch";
       key: string;
       label: string;
+      /** Branch keyword / condition span. */
+      file?: string;
+      line?: number;
+      endLine?: number;
       children: CallStep[];
     };
 
@@ -32,6 +56,9 @@ export interface DiffNode {
   label: string;
   status: DiffStatus;
   kind?: CallNodeKind;
+  file?: string;
+  line?: number;
+  endLine?: number;
   children: DiffNode[];
 }
 
@@ -46,6 +73,9 @@ export interface FunctionInfo {
   /** Source span for change detection */
   start: number;
   end: number;
+  /** 1-based definition line (derived from start/end + source) */
+  line?: number;
+  endLine?: number;
 }
 
 export interface Snapshot {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,6 +7,11 @@ export type CallstackDiffOptions = {
   maxDepth?: number;
   /** Filename used for language detection (e.g. `file.tsx`). */
   file?: string;
+  /**
+   * Include `file:line` suffixes in ASCII. Default false in unit tests
+   * so language fixtures stay focused on call structure.
+   */
+  locs?: boolean;
 };
 
 /**
@@ -92,7 +97,7 @@ export function callstackDiff(
   const beforeTree = buildCallTree(entry, before, maxDepth);
   const afterTree = buildCallTree(entry, after, maxDepth);
   const diff = diffTrees(beforeTree, afterTree);
-  return renderDiff(diff, { color: false });
+  return renderDiff(diff, { color: false, locs: options.locs === true });
 }
 
 /**
@@ -108,5 +113,5 @@ export function callstackShow(
   const file = options.file ?? "file.ts";
   const index = buildIndex(extractFunctions(file, source));
   const tree = buildCallTree(entry, index, maxDepth);
-  return renderTree(tree, { color: false });
+  return renderTree(tree, { color: false, locs: options.locs === true });
 }

--- a/test/locs.test.ts
+++ b/test/locs.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { buildCallTree } from "../src/calltree.js";
+import { buildIndex, extractFunctions } from "../src/extract.js";
+import { renderTree } from "../src/render.js";
+
+const checkoutDir = join(process.cwd(), "examples/checkout");
+
+function loadCheckoutIndex() {
+  const files = [
+    "checkout.ts",
+    "cart.ts",
+    "inventory.ts",
+    "payments.ts",
+    "notify.ts",
+  ];
+  const all = files.flatMap((name) => {
+    const file = `examples/checkout/${name}`;
+    const source = readFileSync(join(checkoutDir, name), "utf8");
+    return extractFunctions(file, source);
+  });
+  return buildIndex(all);
+}
+
+describe("call-site source locations", () => {
+  test("child locs point at the caller file/line, not the callee definition", () => {
+    const index = loadCheckoutIndex();
+    const tree = buildCallTree("runCheckout", index, 12);
+
+    // Root = definition of runCheckout in checkout.ts
+    expect(tree.file).toBe("examples/checkout/checkout.ts");
+    expect(tree.line).toBe(12);
+
+    const cartLoad = tree.children.find((c) => c.key === "Cart.load");
+    expect(cartLoad).toBeTruthy();
+    // Call site is inside runCheckout, not Cart.load's definition in cart.ts
+    expect(cartLoad!.file).toBe("examples/checkout/checkout.ts");
+    expect(cartLoad!.line).toBe(13);
+
+    const readCart = cartLoad!.children.find((c) => c.key === "readCart");
+    expect(readCart).toBeTruthy();
+    // Call site is inside Cart.load in cart.ts (not readCart's own definition)
+    expect(readCart!.file).toBe("examples/checkout/cart.ts");
+    expect(readCart!.line).toBe(8);
+    // Definition of readCart is later in the same file — must not use that line
+    expect(readCart!.line).not.toBe(21);
+  });
+
+  test("ASCII render appends file:line; unresolved calls still show call-site", () => {
+    const source = `
+export function outer() {
+  known();
+  mystery();
+}
+function known() {}
+`;
+    const index = buildIndex(extractFunctions("app.ts", source));
+    const tree = buildCallTree("outer", index, 12);
+    const ascii = renderTree(tree, { color: false, locs: true });
+
+    expect(ascii).toBe(
+      [
+        "outer()  app.ts:2",
+        "├─ known()  app.ts:3",
+        "└─ mystery()  app.ts:4",
+      ].join("\n"),
+    );
+
+    const mystery = tree.children.find((c) => c.key === "mystery");
+    expect(mystery).toMatchObject({
+      file: "app.ts",
+      line: 4,
+    });
+  });
+
+  test("branch nodes carry condition locs; children keep call-site locs", () => {
+    const source = `
+export function gate(ok: boolean) {
+  if (ok) {
+    yes();
+  } else {
+    no();
+  }
+}
+function yes() {}
+function no() {}
+`;
+    const index = buildIndex(extractFunctions("gate.ts", source));
+    const tree = buildCallTree("gate", index, 12);
+    const ifArm = tree.children.find((c) => c.key.startsWith("if:"));
+    const elseArm = tree.children.find((c) => c.key === "else");
+    expect(ifArm?.file).toBe("gate.ts");
+    expect(ifArm?.line).toBe(3);
+    expect(elseArm?.file).toBe("gate.ts");
+
+    expect(ifArm!.children[0]).toMatchObject({
+      key: "yes",
+      file: "gate.ts",
+      line: 4,
+    });
+    expect(elseArm!.children[0]).toMatchObject({
+      key: "no",
+      file: "gate.ts",
+      line: 6,
+    });
+  });
+
+  test("locs:false omits suffixes from ASCII", () => {
+    const source = `
+export function outer() {
+  known();
+}
+function known() {}
+`;
+    const index = buildIndex(extractFunctions("app.ts", source));
+    const tree = buildCallTree("outer", index, 12);
+    expect(renderTree(tree, { color: false, locs: false })).toBe(
+      ["outer()", "└─ known()"].join("\n"),
+    );
+  });
+});

--- a/test/reach.test.ts
+++ b/test/reach.test.ts
@@ -52,7 +52,9 @@ describe("reach paths", () => {
   test("finds every path from entry to target across branches", () => {
     const index = indexOf(source);
     const paths = findReachPaths("runCheckout", "sendEmail", index, 12);
-    const ascii = paths.map((p) => renderTree(p, { color: false }));
+    const ascii = paths.map((p) =>
+      renderTree(p, { color: false, locs: false }),
+    );
 
     expect(ascii).toEqual([
       [
@@ -73,7 +75,7 @@ describe("reach paths", () => {
     const index = indexOf(source);
     const paths = findReachPaths("runCheckout", "capture", index, 12);
     expect(paths).toHaveLength(1);
-    expect(renderTree(paths[0]!, { color: false })).toBe(
+    expect(renderTree(paths[0]!, { color: false, locs: false })).toBe(
       [
         "runCheckout()",
         "└─ PaymentGateway.charge()",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Each call-tree node can show a source location in editor style (`file:line` or `file:line-line`):

- **Root** — definition line of the entrypoint
- **Children** — where the *parent calls* them (call expression span), not where the callee is defined
- **Branches** — condition / keyword span; nested calls still use call-site locs
- **Unresolved / external** calls still get a call-site loc when we have one

This matches LSP Call Hierarchy `fromRanges`, not Go to Definition.

## Changes

- Extend `CallStep` / `CallNode` / `DiffNode` with optional `file` / `line` / `endLine`
- Shared `locFromNode` helper; all language extractors attach locs when recording `addCall` / branches
- Thread locs through `buildCallTree`, `diffTrees`, `pathToTree`, and JSON serialization
- ASCII render appends dimmed locs when `--locs` is set (**default off**); JSON still includes `file` / `line` / `endLine` on nodes when present
- Tests for the checkout fixture asserting child locs point at the caller file/line

## Example

```
# without --locs (default)
runCheckout(userId, cartId)
└─ Cart.load(cartId)
   └─ readCart(cartId)

# with --locs
runCheckout(userId, cartId)  examples/checkout/checkout.ts:12
└─ Cart.load(cartId)  examples/checkout/checkout.ts:13
   └─ readCart(cartId)  examples/checkout/cart.ts:8
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13c201f6-9655-493a-81b1-ba73a53a87cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13c201f6-9655-493a-81b1-ba73a53a87cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

