### PR TITLE
Expose the public library entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.4.1",
   "description": "Diff call stacks across git commits for agentic code review (22 languages)",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "calldiff": "dist/cli.js"
   },


### PR DESCRIPTION
**Why**

`src/index.ts` already exports `runDiff`, `runTree`, `runReach`, render helpers, and their result types. The published package has no root export, so integrations cannot import that API without using an internal `dist` path.

I need the supported root import for critique's experimental call-stack diff view. I published the same package surface temporarily as [`@xmorse/calldiff`](https://www.npmjs.com/package/@xmorse/calldiff) to validate the integration end to end.

**Change**

Add a root `exports` entry that maps ESM imports to `dist/index.js` and TypeScript resolution to `dist/index.d.ts`. The CLI binary and existing runtime behavior stay unchanged.

```ts
import { runDiff, type DiffResult } from 'calldiff'
```

**Validation**

- `npm run build`
- `npm test -- test/callstack-diff.test.ts test/locs.test.ts test/args.test.ts`, 34 tests passed
- Packed the package, installed the tarball under Bun, and verified the root `runDiff` import
- The full language suite was also attempted. Unrelated on-demand grammar tests failed because parallel npm installs wrote to the same temporary grammar cache.