### PR TITLE
Label React hook dependency arrays in call trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Prints every call path from the entrypoint to the target (including alternate `i
 - `ClassName.method` — class method
 - `new ClassName` — constructor / `new` call
 - `Component` — JSX/TSX component tags (`<Button />`); children nest under the parent
+- `useEffect([userId])` — React hooks show their dependency array (`useEffect`, `useLayoutEffect`, `useInsertionEffect`, `useMemo`, `useCallback`, `useImperativeHandle`); dep changes surface in diffs as `- useEffect([query])` / `+ useEffect([query, page])`
 - `if (cond)` / `else` / `else if (cond)` — conditional arms (no continuing `│` rail)
 - `file:line` — call-site (or root definition) location; enable with `--locs` (default off)
 

--- a/src/languages/javascript.ts
+++ b/src/languages/javascript.ts
@@ -2,6 +2,7 @@
  * JavaScript / JSX callable extraction (tree-sitter-javascript).
  */
 import type { CallStep, FunctionInfo } from "../types.js";
+import { withHookDeps } from "./reactHooks.js";
 import {
   childByType,
   collapseWs,
@@ -338,7 +339,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node);
+        if (key) addCall(withHookDeps(key, node), node);
       }
     } else if (type === "new_expression") {
       const callee = node.namedChild(0);

--- a/src/languages/reactHooks.ts
+++ b/src/languages/reactHooks.ts
@@ -1,0 +1,51 @@
+/**
+ * React hook dependency arrays (JS / TS / JSX / TSX).
+ *
+ * Effects and memoization hooks re-run when their dependency array changes,
+ * so the deps are part of the call's identity. Including them in the call key
+ * renders them in labels (`useEffect([userId])`) and lets them participate in
+ * diff matching, which makes dep-array churn visible in `calldiff diff`.
+ */
+import {
+  childByType,
+  collapseWs,
+  namedChildren,
+  type SyntaxNode,
+} from "./types.js";
+
+/** Hook name → position of its dependency-array argument. */
+const DEPS_ARG_INDEX: Record<string, number> = {
+  useEffect: 1,
+  useLayoutEffect: 1,
+  useInsertionEffect: 1,
+  useMemo: 1,
+  useCallback: 1,
+  useImperativeHandle: 2,
+};
+
+/** Keep labels one-line friendly when a dep list is unusually long. */
+const MAX_DEPS_TEXT = 60;
+
+/**
+ * Append a React hook's dependency-array literal to its call key:
+ * `useEffect` → `useEffect([userId, refresh])`, `useEffect([])` for
+ * mount-only. Non-hook calls, hooks called without a deps argument, and
+ * non-literal deps (e.g. a spread or identifier) pass through unchanged.
+ */
+export function withHookDeps(key: string, callNode: SyntaxNode): string {
+  const name = key.slice(key.lastIndexOf(".") + 1);
+  const depsIndex = DEPS_ARG_INDEX[name];
+  if (depsIndex === undefined) return key;
+
+  const args = childByType(callNode, "arguments");
+  if (!args) return key;
+  const argNodes = namedChildren(args).filter((c) => c.type !== "comment");
+  const deps = argNodes[depsIndex];
+  if (!deps || deps.type !== "array") return key;
+
+  let text = collapseWs(deps.text);
+  if (text.length > MAX_DEPS_TEXT) {
+    text = `${text.slice(0, MAX_DEPS_TEXT - 1)}…]`;
+  }
+  return `${key}(${text})`;
+}

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -2,6 +2,7 @@
  * TypeScript / TSX callable extraction (tree-sitter-typescript).
  */
 import type { CallStep, FunctionInfo } from "../types.js";
+import { withHookDeps } from "./reactHooks.js";
 import {
   childByType,
   collapseWs,
@@ -226,7 +227,7 @@ function collectStatements(
       const callee = node.namedChild(0);
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node);
+        if (key) addCall(withHookDeps(key, node), node);
       }
     } else if (type === "new_expression") {
       const callee = node.namedChild(0);

--- a/src/reach.ts
+++ b/src/reach.ts
@@ -8,7 +8,8 @@ function nodeMatchesTarget(
   rawTarget: string,
 ): boolean {
   if (nodeKey === resolvedTarget || nodeKey === rawTarget) return true;
-  const stripped = nodeKey.replace(/\(\)$/, "");
+  // Also strip argument suffixes like `([deps])` so `--to useEffect` matches.
+  const stripped = nodeKey.replace(/\(.*\)$/, "");
   if (stripped === resolvedTarget || stripped === rawTarget) return true;
   return (
     nodeKey.endsWith(`.${rawTarget}`) ||

--- a/test/javascriptreact.test.ts
+++ b/test/javascriptreact.test.ts
@@ -36,6 +36,33 @@ test("javascriptreact: tracks JSX components as nested calls", ({
   `);
 });
 
+test("javascriptreact: labels hook dependency arrays", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      export function Ticker({ speed }) {
+    -   useEffect(() => {
+    -     start(speed);
+    -   }, []);
+    +   useEffect(() => {
+    +     start(speed);
+    +   }, [speed]);
+        return <Display />;
+      }
+      function start(_s) {}
+      function Display() { return null; }
+    `,
+    "Ticker",
+    { file: "ticker.jsx" },
+  ).toEqual(`
+      Ticker({})
+    - ├─ useEffect([])
+    + ├─ useEffect([speed])
+      └─ Display()
+  `);
+});
+
 test("javascriptreact: skips lowercase HTML tags, nests components", ({
   expectCallstack,
 }) => {

--- a/test/typescriptreact.test.ts
+++ b/test/typescriptreact.test.ts
@@ -99,6 +99,96 @@ test("typescriptreact: diffs React component trees", ({ expectCallstack }) => {
   `);
 });
 
+test("typescriptreact: labels hook dependency arrays", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      export function Profile({ userId }: { userId: string }) {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          setUser(userId);
+        }, [userId]);
+        const label = useMemo(() => String(user), [user]);
+    +   const onSelect = useCallback(() => select(userId), [userId, select]);
+        useEffect(() => {
+          log(label);
+        });
+        return <Badge title={label} />;
+      }
+      function Badge(_props: { title: string }) {
+        return null;
+      }
+    `,
+    "Profile",
+    { file: "Profile.tsx" },
+  ).toEqual(`
+      Profile({})
+      ├─ useState()
+      ├─ useEffect([userId])
+      ├─ useMemo([user])
+    + ├─ useCallback([userId, select])
+      ├─ useEffect()
+      └─ Badge(_props)
+  `);
+});
+
+test("typescriptreact: dep-array changes surface in the diff", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      export function Search({ query, page }: { query: string; page: number }) {
+    -   useEffect(() => {
+    -     fetchResults(query);
+    -   }, [query]);
+    +   useEffect(() => {
+    +     fetchResults(query, page);
+    +   }, [query, page]);
+        return <Results />;
+      }
+      function fetchResults(_q: string, _p?: number) {}
+      function Results() {
+        return null;
+      }
+    `,
+    "Search",
+    { file: "Search.tsx" },
+  ).toEqual(`
+      Search({})
+    - ├─ useEffect([query])
+    + ├─ useEffect([query, page])
+      └─ Results()
+  `);
+});
+
+test("typescript: labels hook deps in custom hook files", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      export function useThing(id: string) {
+        const value = useMemo(() => compute(id), [id]);
+        useEffect(() => {
+          subscribe(id);
+    -   }, []);
+    +   }, [id]);
+        return value;
+      }
+      function compute(_id: string) {
+        return 1;
+      }
+    `,
+    "useThing",
+    { file: "useThing.ts" },
+  ).toEqual(`
+      useThing(id)
+      ├─ useMemo([id])
+    - ├─ useEffect([])
+    + └─ useEffect([id])
+  `);
+});
+
 test("typescriptreact: recursive JSX keeps nested call-site children", ({
   expectCallstack,
 }) => {


### PR DESCRIPTION
Hooks that take a dependency array now show it in the tree. The deps go into the call key, so dep changes show up in `calldiff diff`:

```diff
  CompareSheet({})
  ├─ useMemo([snapshot.models, mode])
  ├─ useEffect([snapshot.snapshot_id])
+ ├─ useEffect([])
  ├─ useEffect([onClose])
```

Before this, every effect rendered as a bare `useEffect()` and a dep-array change was invisible in the diff.

Covers `useEffect`, `useLayoutEffect`, `useInsertionEffect`, `useMemo`, `useCallback`, and `useImperativeHandle` in JS/JSX/TS/TSX.

- No deps argument, or deps that aren't an array literal (identifier, spread): key is unchanged, renders like today.
- Dep lists longer than 60 chars truncate with `…]`.
- `reach` target matching strips argument suffixes, so `--to useEffect` still matches labeled nodes.

Tested with new fixtures in the tsx/jsx suites plus a plain-.ts custom hook case, and against a real repo: a component with three effects went from three identical `useEffect()` lines to `[snapshot.snapshot_id]`, `[]`, and `[onClose]`.
