### PR TITLE
Add calldiff agent skill at skills/calldiff/SKILL.md

### DIFF
--- a/skills/calldiff/SKILL.md
+++ b/skills/calldiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: calldiff
-description: Diff call stacks across git commits for agentic code review (22 languages). Run `calldiff --help` for usage details.
+description: Diff call stacks across git commits — like git diff, but for who-calls-whom. Shows which callees appeared, disappeared, or moved under an entrypoint across 22 languages (diff, tree, and reach). Use for agentic code review when call flow changed and line diffs bury the shape of the change.
 requires_bin: calldiff
 command: calldiff
 ---

--- a/skills/calldiff/SKILL.md
+++ b/skills/calldiff/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: calldiff
+description: Diff call stacks across git commits for agentic code review (22 languages). Run `calldiff --help` for usage details.
+requires_bin: calldiff
+command: calldiff
+---
+
+# calldiff diff
+
+Diff call stacks between two git trees
+
+## Arguments
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `from` | `string` | no | Before ref (default: HEAD) |
+| `to` | `string` | no | After ref (default: working tree) |
+| `paths` | `array` | no | Limit to these path prefixes |
+
+## Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--entry` | `unknown` |  |  |
+| `--maxDepth` | `number` | `12` | Max call-tree depth |
+| `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
+| `--from` | `string` |  | Left / "before" tree |
+| `--to` | `string` |  | Right / "after" tree |
+
+## Examples
+
+```sh
+# HEAD vs working tree
+calldiff diff
+
+# One ref vs working tree
+calldiff diff main
+
+# Two commits / branches
+calldiff diff abc123 def456
+
+# Force entrypoints
+calldiff diff main feature --entry createAgentSession
+```
+
+> Semantics match git diff: no refs → HEAD vs worktree; one ref → that vs worktree; two refs → compare those trees.
+
+---
+
+# calldiff reach
+
+Find all call paths from an entrypoint to a target symbol
+
+## Arguments
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `ref` | `string` | no | Git ref (default: working tree) |
+| `paths` | `array` | no | Limit to these path prefixes |
+
+## Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--entry` | `unknown` |  | Entrypoint(s): functionName or ClassName.method |
+| `--to` | `string` |  | Target symbol to reach (functionName or ClassName.method) |
+| `--maxDepth` | `number` | `12` | Max call-tree depth |
+| `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
+
+## Examples
+
+```sh
+# Paths in the working tree
+calldiff reach --entry runCheckout --to sendEmail
+
+# Paths at a commit, limited to a directory
+calldiff reach HEAD examples/checkout --entry runCheckout --to sendEmail
+```
+
+---
+
+# calldiff tree
+
+View a call tree (no diff) for one or more entrypoints
+
+## Arguments
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `ref` | `string` | no | Git ref (default: working tree) |
+| `paths` | `array` | no | Limit to these path prefixes |
+
+## Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--entry` | `unknown` |  | Entrypoint(s): functionName or ClassName.method |
+| `--maxDepth` | `number` | `12` | Max call-tree depth |
+| `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
+
+## Examples
+
+```sh
+# Tree from working tree
+calldiff tree --entry createAgentSession
+
+# Tree from a commit
+calldiff tree HEAD --entry PiService.createAgentSession
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a committed agent skill generated from the calldiff CLI via incur Skillgen (`depth: 0`), so it can be installed from this repo with the skills CLI (`npx skills add …`).

The file covers `diff`, `tree`, and `reach`. The frontmatter description is customized for discovery: what calldiff does (call-stack diffs across commits) plus a “Use for …” sentence for when agents should load it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fedcf-02b3-7efe-ac97-812fbf4d8458?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fedcf-02b3-7efe-ac97-812fbf4d8458&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

