### PR TITLE
fix(cli): make --token-count/--token-limit/--token-offset work in default ASCII mode

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,8 +19,31 @@ function readVersion(): string {
   }
 }
 
+const TOKEN_FLAGS = ["--token-count", "--token-limit", "--token-offset"];
+
+/**
+ * Whether the user asked incur to count or slice the output by tokens.
+ *
+ * These globals act on the value a command *returns*, so the ASCII fast path
+ * (which writes to stdout itself) has to opt out of them — otherwise the flags
+ * silently do nothing. See `emitAsciiOrData`.
+ */
+export function hasTokenFlag(argv: string[]): boolean {
+  return argv.some((token) =>
+    TOKEN_FLAGS.some((flag) => token === flag || token.startsWith(`${flag}=`)),
+  );
+}
+
+/**
+ * Set from the argv actually being served. incur does not pass the raw argv to
+ * command handlers, and `normalizeArgv` is the one funnel every entry point
+ * (the CLI below, and the tests) already runs argv through.
+ */
+let tokenFlagActive = false;
+
 /** Strip lone `--` so `calldiff a b -- src` still works with incur. */
 export function normalizeArgv(argv: string[]): string[] {
+  tokenFlagActive = hasTokenFlag(argv);
   return argv.filter((token) => token !== "--");
 }
 
@@ -50,6 +73,13 @@ type EmitContext = {
 /**
  * Default: classic ASCII (TTY + pipes) with optional CTAs.
  * `--format` / `--json`: structured envelope for agents.
+ *
+ * The ASCII path writes to stdout itself so that piped output stays raw text
+ * (incur wraps a scalar payload as `{ data, cta }` once a CTA is attached).
+ * `--token-count` / `--token-limit` / `--token-offset` act on what a command
+ * *returns*, though, so under those flags we hand the ASCII back to incur and
+ * let it do the counting and slicing. The CTA is dropped there on purpose: it
+ * keeps the counted output exactly the tree the user asked about.
  */
 function emitAsciiOrData(
   c: EmitContext,
@@ -57,6 +87,7 @@ function emitAsciiOrData(
   cta?: CtaMeta,
 ): unknown {
   if (!c.formatExplicit) {
+    if (tokenFlagActive) return result.ascii;
     process.stdout.write(
       result.ascii.endsWith("\n") ? result.ascii : `${result.ascii}\n`,
     );

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,19 +1,30 @@
 import { describe, expect, test } from "vitest";
-import { cli, normalizeArgv } from "../src/cli.js";
+import { cli, hasTokenFlag, normalizeArgv } from "../src/cli.js";
 
 async function invoke(
   argv: string[],
 ): Promise<{ stdout: string; code: number | undefined }> {
   let stdout = "";
   let code: number | undefined;
-  await cli.serve(normalizeArgv(argv), {
-    stdout: (s) => {
-      stdout += s;
-    },
-    exit: (c) => {
-      code = c;
-    },
-  });
+  // The default ASCII path writes to process.stdout itself, so capture both
+  // that and incur's injected writer.
+  const realWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await cli.serve(normalizeArgv(argv), {
+      stdout: (s) => {
+        stdout += s;
+      },
+      exit: (c) => {
+        code = c;
+      },
+    });
+  } finally {
+    process.stdout.write = realWrite;
+  }
   return { stdout, code };
 }
 
@@ -32,6 +43,50 @@ describe("normalizeArgv", () => {
       "-e",
       "boot",
     ]);
+  });
+});
+
+describe("hasTokenFlag", () => {
+  test("detects each token flag", () => {
+    expect(hasTokenFlag(["tree", "--token-count"])).toBe(true);
+    expect(hasTokenFlag(["tree", "--token-limit", "50"])).toBe(true);
+    expect(hasTokenFlag(["tree", "--token-offset", "10"])).toBe(true);
+  });
+
+  test("detects the --flag=value form", () => {
+    expect(hasTokenFlag(["tree", "--token-limit=50"])).toBe(true);
+  });
+
+  test("is false without one", () => {
+    expect(hasTokenFlag(["tree", "-e", "boot"])).toBe(false);
+    expect(hasTokenFlag(["diff", "--max-depth", "3"])).toBe(false);
+  });
+});
+
+// Regression: these incur globals act on a command's return value, so the
+// ASCII fast path used to swallow them — `--token-limit` printed everything
+// and `--token-count` reported 0.
+describe("token flags in default ASCII mode", () => {
+  const entry = ["tree", "--entry", "buildCallTree"];
+
+  test("--token-count reports a real count", async () => {
+    const { stdout } = await invoke([...entry, "--token-count"]);
+    const count = Number(stdout.trim());
+    expect(Number.isInteger(count)).toBe(true);
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("--token-limit actually truncates", async () => {
+    const full = await invoke(entry);
+    const limited = await invoke([...entry, "--token-limit", "20"]);
+    expect(limited.stdout).toMatch(/truncated: showing tokens/);
+    expect(limited.stdout.length).toBeLessThan(full.stdout.length);
+  });
+
+  test("output is unchanged without the flags", async () => {
+    const { stdout } = await invoke(entry);
+    expect(stdout).toMatch(/buildCallTree/);
+    expect(stdout).not.toMatch(/truncated: showing tokens/);
   });
 });
 


### PR DESCRIPTION
## The problem

All three token globals are silent no-ops in the default output mode:

```console
$ calldiff tree --entry buildCallTree --token-limit 20
# ...printed the whole tree, unchanged

$ calldiff tree --entry buildCallTree --token-count
0
```

They only work under an explicit `--format`:

| | `--token-limit 20` | `--token-count` |
|---|---|---|
| default ASCII | no-op | `0` |
| `--format json` | truncates correctly | `395` |

## Why

`incur` applies the token machinery inside its `write(output)` path, over the value a command **returns**. But `emitAsciiOrData` (`src/cli.ts`) takes a shortcut for the ASCII path:

```ts
if (!c.formatExplicit) {
  process.stdout.write(...)   // ← bypasses incur entirely
  if (cta) return c.ok({}, cta)
  return                      // ← nothing for incur to count or slice
}
```

So incur counts an empty payload (`0`), and the tree reaches the terminal through a channel it never sees.

This matters most for the tool's main audience: `calldiff diff` on a real commit ran to ~80k tokens on one of my repos, and `--token-limit` is exactly the flag that should have made that manageable.

## The fix

Detect the flags from the argv being served; when one is present, return the ASCII string so incur can count and slice it.

I deliberately **kept** the direct write for the normal path. It is load-bearing: once a CTA is attached, incur wraps a scalar payload as `{ data, cta }` (`Cli.ts:1592`), so routing everything through incur would change piped output for `diff`. The CTA is dropped under the token flags so the counted output is exactly the tree that was asked for.

The flag state rides on `normalizeArgv` because incur does not pass raw argv to command handlers, and that function is already the single funnel every entry point runs argv through.

## Verification

```console
$ calldiff tree --entry buildCallTree --token-count
395

$ calldiff tree --entry buildCallTree --token-limit 20
calldiff tree working tree

buildCallTree(entryKey, index, maxDepth)
├─
[truncated: showing tokens 0–20 of 395]
```

Checked for regressions on the paths this touches — normal ASCII output, `diff` piped (the CTA case), `--format json`, and `--token-offset` — all unchanged or now correct.

`tsc --noEmit` clean. Tests: 59 passing across the suites that run here.

> Note: on a fresh clone `npm test` fails 19/30 files for me because the non-TypeScript grammars auto-install to a temp cache and the native bindings fail to build in my environment. That is unrelated to this change; I ran the TypeScript-side suites (`args`, `typescriptreact`, `reach`, `callstack-diff`, `callstack-show`, `infer`, `locs`, `extract-cache`, `git`).

## Tests added

- unit coverage for `hasTokenFlag`, including the `--flag=value` form
- regression tests that `--token-count` reports a real count and `--token-limit` truncates in default mode, plus one asserting unflagged output is unchanged

The shared `invoke` helper now also captures `process.stdout` — the direct write had been escaping it, which is why this class of bug was invisible to the harness.
