### PR TITLE
feat: add --file / -F for file entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ calldiff mcp add      # register as MCP server
 
 If you omit `--entry`, calldiff infers exported functions whose expanded call trees changed (and may show several).
 
-A source file path as `--entry` / `-e` expands to every **exported** symbol defined in that file (useful in monorepos). Bare names with a supported extension count (`routes.ts`); so do paths with separators (`packages/api/src/routes.ts`). Ambiguous suffix matches error so you can pass a more specific path.
+A `--entry` / `-e` value that uniquely matches an **indexed source file** expands to every **exported** symbol defined in that file (useful in monorepos). Matching is by lookup against the snapshot — exact path, or a unique suffix (`boot.ts` → `packages/api/src/boot.ts`) — not by guessing from the string shape. Ambiguous suffix matches error so you can pass a more specific path; values that match no file are resolved as symbols.
 
 ### `tree`
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ calldiff diff main
 calldiff diff abc123 def456
 calldiff diff --from main --to feature
 
-# force entrypoints (functionName, ClassName.method, or a source file path)
+# force entrypoints (functionName or ClassName.method)
 calldiff diff main feature --entry createAgentSession
 calldiff diff main feature -e PiService.createAgentSession -e boot
-calldiff tree -e src/routes.ts
-calldiff tree -e packages/api/src/boot.ts
+
+# file as entrypoint (every export in that indexed source file)
+calldiff tree --file src/routes.ts
+calldiff tree -F packages/api/src/boot.ts
+calldiff diff main HEAD --file src/routes.ts
 
 # limit to paths (trailing positionals; leading -- also accepted)
 calldiff diff main feature src/lib
@@ -79,9 +82,9 @@ calldiff mcp add      # register as MCP server
 `-` lines were present in **from** and gone in **to**.  
 `+` lines are new in **to**.
 
-If you omit `--entry`, calldiff infers exported functions whose expanded call trees changed (and may show several).
+If you omit `--entry` / `--file`, calldiff infers exported functions whose expanded call trees changed (and may show several).
 
-A `--entry` / `-e` value that uniquely matches an **indexed source file** expands to every **exported** symbol defined in that file (useful in monorepos). Matching is by lookup against the snapshot — exact path, or a unique suffix (`boot.ts` → `packages/api/src/boot.ts`) — not by guessing from the string shape. Ambiguous suffix matches error so you can pass a more specific path; values that match no file are resolved as symbols.
+`--file` / `-F` takes an indexed source path and expands to every **exported** symbol defined in that file (useful in monorepos). Matching is exact path, or a unique suffix (`boot.ts` → `packages/api/src/boot.ts`). Ambiguous matches error so you can pass a more specific path. `--entry` / `-e` is symbols only.
 
 ### `tree`
 
@@ -90,7 +93,7 @@ A `--entry` / `-e` value that uniquely matches an **indexed source file** expand
 | `calldiff tree -e <name>` | working tree |
 | `calldiff tree <ref> -e <name>` | that commit/ref |
 
-Prints a plain ASCII call tree (no `+/−` markers). `--entry` / `-e` is required.
+Prints a plain ASCII call tree (no `+/−` markers). `--entry` / `-e` or `--file` / `-F` is required.
 With `--locs`, each node shows a source location: the root uses the definition
 `file:line`, and children use the **call site** in the parent (`file:line` or
 `file:line-line`) — same idea as LSP Call Hierarchy `fromRanges`, not Go to
@@ -103,7 +106,7 @@ Definition.
 | `calldiff reach -e <from> --to <target>` | working tree |
 | `calldiff reach <ref> -e <from> --to <target>` | that commit/ref |
 
-Prints every call path from the entrypoint to the target (including alternate `if` / `else` arms). Both `--entry` / `-e` and `--to` are required.
+Prints every call path from the entrypoint to the target (including alternate `if` / `else` arms). `--entry` / `-e` or `--file` / `-F`, plus `--to`, are required.
 
 ### Labels
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ calldiff diff main
 calldiff diff abc123 def456
 calldiff diff --from main --to feature
 
-# force entrypoints (functionName or ClassName.method)
+# force entrypoints (functionName, ClassName.method, or a source file path)
 calldiff diff main feature --entry createAgentSession
 calldiff diff main feature -e PiService.createAgentSession -e boot
+calldiff tree -e src/routes.ts
+calldiff tree -e packages/api/src/boot.ts
 
 # limit to paths (trailing positionals; leading -- also accepted)
 calldiff diff main feature src/lib
@@ -78,6 +80,8 @@ calldiff mcp add      # register as MCP server
 `+` lines are new in **to**.
 
 If you omit `--entry`, calldiff infers exported functions whose expanded call trees changed (and may show several).
+
+A source file path as `--entry` / `-e` expands to every **exported** symbol defined in that file (useful in monorepos). Bare names with a supported extension count (`routes.ts`); so do paths with separators (`packages/api/src/routes.ts`). Ambiguous suffix matches error so you can pass a more specific path.
 
 ### `tree`
 

--- a/skills/calldiff/SKILL.md
+++ b/skills/calldiff/SKILL.md
@@ -21,7 +21,7 @@ Diff call stacks between two git trees
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  |  |
+| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or source file path |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
 | `--from` | `string` |  | Left / "before" tree |
@@ -41,6 +41,9 @@ calldiff diff abc123 def456
 
 # Force entrypoints
 calldiff diff main feature --entry createAgentSession
+
+# File path expands to that file's exports
+calldiff diff main feature --entry src/routes.ts
 ```
 
 > Semantics match git diff: no refs → HEAD vs worktree; one ref → that vs worktree; two refs → compare those trees.
@@ -62,7 +65,7 @@ Find all call paths from an entrypoint to a target symbol
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName or ClassName.method |
+| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or source file path |
 | `--to` | `string` |  | Target symbol to reach (functionName or ClassName.method) |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
@@ -94,7 +97,7 @@ View a call tree (no diff) for one or more entrypoints
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName or ClassName.method |
+| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or source file path |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
 
@@ -106,4 +109,7 @@ calldiff tree --entry createAgentSession
 
 # Tree from a commit
 calldiff tree HEAD --entry PiService.createAgentSession
+
+# Every export in a file
+calldiff tree --entry packages/api/src/routes.ts
 ```

--- a/skills/calldiff/SKILL.md
+++ b/skills/calldiff/SKILL.md
@@ -21,7 +21,8 @@ Diff call stacks between two git trees
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or indexed source file path |
+| `--entry` | `unknown` |  | Entrypoint symbol(s): functionName or ClassName.method |
+| `--file` | `unknown` |  | Entrypoint file(s): indexed source path; expands to that file's exports |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
 | `--from` | `string` |  | Left / "before" tree |
@@ -42,8 +43,8 @@ calldiff diff abc123 def456
 # Force entrypoints
 calldiff diff main feature --entry createAgentSession
 
-# File path expands to that file's exports
-calldiff diff main feature --entry src/routes.ts
+# File expands to that file's exports
+calldiff diff main feature --file src/routes.ts
 ```
 
 > Semantics match git diff: no refs → HEAD vs worktree; one ref → that vs worktree; two refs → compare those trees.
@@ -65,7 +66,8 @@ Find all call paths from an entrypoint to a target symbol
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or indexed source file path |
+| `--entry` | `unknown` |  | Entrypoint symbol(s): functionName or ClassName.method |
+| `--file` | `unknown` |  | Entrypoint file(s): indexed source path; expands to that file's exports |
 | `--to` | `string` |  | Target symbol to reach (functionName or ClassName.method) |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
@@ -78,6 +80,9 @@ calldiff reach --entry runCheckout --to sendEmail
 
 # Paths at a commit, limited to a directory
 calldiff reach HEAD examples/checkout --entry runCheckout --to sendEmail
+
+# Paths from every export in a file
+calldiff reach --file packages/api/src/flow.ts --to notify
 ```
 
 ---
@@ -97,7 +102,8 @@ View a call tree (no diff) for one or more entrypoints
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or indexed source file path |
+| `--entry` | `unknown` |  | Entrypoint symbol(s): functionName or ClassName.method |
+| `--file` | `unknown` |  | Entrypoint file(s): indexed source path; expands to that file's exports |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
 
@@ -111,5 +117,5 @@ calldiff tree --entry createAgentSession
 calldiff tree HEAD --entry PiService.createAgentSession
 
 # Every export in a file
-calldiff tree --entry packages/api/src/routes.ts
+calldiff tree --file packages/api/src/routes.ts
 ```

--- a/skills/calldiff/SKILL.md
+++ b/skills/calldiff/SKILL.md
@@ -21,7 +21,7 @@ Diff call stacks between two git trees
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or source file path |
+| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or indexed source file path |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
 | `--from` | `string` |  | Left / "before" tree |
@@ -65,7 +65,7 @@ Find all call paths from an entrypoint to a target symbol
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or source file path |
+| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or indexed source file path |
 | `--to` | `string` |  | Target symbol to reach (functionName or ClassName.method) |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
@@ -97,7 +97,7 @@ View a call tree (no diff) for one or more entrypoints
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or source file path |
+| `--entry` | `unknown` |  | Entrypoint(s): functionName, ClassName.method, or indexed source file path |
 | `--maxDepth` | `number` | `12` | Max call-tree depth |
 | `--locs` | `boolean` | `false` | Show call-site source locations (file:line) |
 

--- a/src/calltree.ts
+++ b/src/calltree.ts
@@ -1,6 +1,4 @@
-import { extname } from "node:path";
 import { allFunctions, type FunctionIndex } from "./extract.js";
-import { listSupportedExtensions } from "./languages/registry.js";
 import { pickLoc } from "./loc.js";
 import type { CallNode, CallStep, FunctionInfo } from "./types.js";
 
@@ -9,21 +7,13 @@ export function normalizeEntryPath(entry: string): string {
   return entry.replace(/\\/g, "/").replace(/^\.\//, "");
 }
 
-/**
- * True when `-e` should be treated as a source file path rather than a symbol.
- * Path separators always count; a bare name counts only with a supported ext
- * (e.g. `routes.ts`, not `ClassName.method`).
- */
-export function isFileEntrypoint(entry: string): boolean {
-  const normalized = normalizeEntryPath(entry);
-  if (normalized.includes("/")) return true;
-  const ext = extname(normalized).toLowerCase();
-  if (!ext) return false;
-  return listSupportedExtensions().includes(ext);
+/** Unique source paths present in an index. */
+export function indexedFiles(index: FunctionIndex): string[] {
+  return [...new Set(allFunctions(index).map((fn) => fn.file))].sort();
 }
 
 /**
- * Resolve which indexed source files match a file entrypoint.
+ * Resolve which indexed source files match an entry string.
  * Exact path wins; otherwise a unique suffix match (`routes.ts` → `src/routes.ts`).
  */
 export function matchEntrypointFiles(
@@ -42,6 +32,68 @@ export function matchEntrypointFiles(
     .sort();
 }
 
+export type ClassifiedEntrypoint =
+  | { kind: "file"; file: string }
+  | { kind: "symbol"; key: string };
+
+/**
+ * Decide whether `-e` names an indexed file or a symbol — by lookup, not by
+ * guessing from the string shape. Unique file match wins; otherwise symbol.
+ */
+export function classifyEntrypoint(
+  entry: string,
+  index: FunctionIndex,
+): ClassifiedEntrypoint {
+  const files = matchEntrypointFiles(entry, indexedFiles(index));
+  if (files.length > 1) {
+    throw new Error(
+      `Ambiguous entrypoint file: ${entry} matches ${files.join(", ")}. Use a more specific path.`,
+    );
+  }
+  if (files.length === 1) {
+    return { kind: "file", file: files[0]! };
+  }
+  const key = resolveEntry(entry, index);
+  if (key) return { kind: "symbol", key };
+  throw new Error(`Entrypoint not found: ${entry}`);
+}
+
+/**
+ * Like {@link classifyEntrypoint}, but file identity is taken from the union of
+ * both snapshots (so a path that exists on only one side still counts as a file).
+ */
+export function classifyEntrypointAcross(
+  entry: string,
+  before: FunctionIndex,
+  after: FunctionIndex,
+): ClassifiedEntrypoint {
+  const files = matchEntrypointFiles(entry, [
+    ...indexedFiles(before),
+    ...indexedFiles(after),
+  ]);
+  if (files.length > 1) {
+    throw new Error(
+      `Ambiguous entrypoint file: ${entry} matches ${files.join(", ")}. Use a more specific path.`,
+    );
+  }
+  if (files.length === 1) {
+    return { kind: "file", file: files[0]! };
+  }
+  const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
+  if (key) return { kind: "symbol", key };
+  throw new Error(`Entrypoint not found: ${entry}`);
+}
+
+/** Exported definitions in a concrete source path. */
+export function exportsInFile(
+  file: string,
+  index: FunctionIndex,
+): FunctionInfo[] {
+  return sortDefinitions(
+    allFunctions(index).filter((fn) => fn.file === file && fn.exported),
+  );
+}
+
 /**
  * Exported definitions in the file matched by `entry`.
  * Throws when the path is ambiguous across multiple indexed files.
@@ -51,19 +103,14 @@ export function resolveFileEntrypoints(
   entry: string,
   index: FunctionIndex,
 ): FunctionInfo[] {
-  const all = allFunctions(index);
-  const matched = matchEntrypointFiles(
-    entry,
-    all.map((fn) => fn.file),
-  );
+  const matched = matchEntrypointFiles(entry, indexedFiles(index));
   if (matched.length === 0) return [];
   if (matched.length > 1) {
     throw new Error(
       `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
     );
   }
-  const file = matched[0]!;
-  return sortDefinitions(all.filter((fn) => fn.file === file && fn.exported));
+  return exportsInFile(matched[0]!, index);
 }
 
 function displayCallLabel(

--- a/src/calltree.ts
+++ b/src/calltree.ts
@@ -1,6 +1,70 @@
+import { extname } from "node:path";
 import { allFunctions, type FunctionIndex } from "./extract.js";
+import { listSupportedExtensions } from "./languages/registry.js";
 import { pickLoc } from "./loc.js";
 import type { CallNode, CallStep, FunctionInfo } from "./types.js";
+
+/** Normalize user-facing paths for entry matching (`\` → `/`, strip `./`). */
+export function normalizeEntryPath(entry: string): string {
+  return entry.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+/**
+ * True when `-e` should be treated as a source file path rather than a symbol.
+ * Path separators always count; a bare name counts only with a supported ext
+ * (e.g. `routes.ts`, not `ClassName.method`).
+ */
+export function isFileEntrypoint(entry: string): boolean {
+  const normalized = normalizeEntryPath(entry);
+  if (normalized.includes("/")) return true;
+  const ext = extname(normalized).toLowerCase();
+  if (!ext) return false;
+  return listSupportedExtensions().includes(ext);
+}
+
+/**
+ * Resolve which indexed source files match a file entrypoint.
+ * Exact path wins; otherwise a unique suffix match (`routes.ts` → `src/routes.ts`).
+ */
+export function matchEntrypointFiles(
+  entry: string,
+  files: Iterable<string>,
+): string[] {
+  const normalized = normalizeEntryPath(entry);
+  const unique = [...new Set(files)];
+  const exact = unique.filter((file) => file === normalized);
+  if (exact.length > 0) return exact.sort();
+  return unique
+    .filter(
+      (file) =>
+        file === normalized || file.endsWith(`/${normalized}`),
+    )
+    .sort();
+}
+
+/**
+ * Exported definitions in the file matched by `entry`.
+ * Throws when the path is ambiguous across multiple indexed files.
+ * Returns [] when nothing matches (caller decides not-found vs no-exports).
+ */
+export function resolveFileEntrypoints(
+  entry: string,
+  index: FunctionIndex,
+): FunctionInfo[] {
+  const all = allFunctions(index);
+  const matched = matchEntrypointFiles(
+    entry,
+    all.map((fn) => fn.file),
+  );
+  if (matched.length === 0) return [];
+  if (matched.length > 1) {
+    throw new Error(
+      `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
+    );
+  }
+  const file = matched[0]!;
+  return sortDefinitions(all.filter((fn) => fn.file === file && fn.exported));
+}
 
 function displayCallLabel(
   key: string,

--- a/src/calltree.ts
+++ b/src/calltree.ts
@@ -13,7 +13,7 @@ export function indexedFiles(index: FunctionIndex): string[] {
 }
 
 /**
- * Resolve which indexed source files match an entry string.
+ * Resolve which indexed source files match a `--file` argument.
  * Exact path wins; otherwise a unique suffix match (`routes.ts` → `src/routes.ts`).
  */
 export function matchEntrypointFiles(
@@ -32,56 +32,24 @@ export function matchEntrypointFiles(
     .sort();
 }
 
-export type ClassifiedEntrypoint =
-  | { kind: "file"; file: string }
-  | { kind: "symbol"; key: string };
-
 /**
- * Decide whether `-e` names an indexed file or a symbol — by lookup, not by
- * guessing from the string shape. Unique file match wins; otherwise symbol.
+ * Resolve a `--file` argument to a single indexed source path.
+ * Throws when missing or ambiguous.
  */
-export function classifyEntrypoint(
+export function resolveEntrypointFile(
   entry: string,
-  index: FunctionIndex,
-): ClassifiedEntrypoint {
-  const files = matchEntrypointFiles(entry, indexedFiles(index));
-  if (files.length > 1) {
+  files: Iterable<string>,
+): string {
+  const matched = matchEntrypointFiles(entry, files);
+  if (matched.length === 0) {
+    throw new Error(`Entrypoint file not found: ${entry}`);
+  }
+  if (matched.length > 1) {
     throw new Error(
-      `Ambiguous entrypoint file: ${entry} matches ${files.join(", ")}. Use a more specific path.`,
+      `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
     );
   }
-  if (files.length === 1) {
-    return { kind: "file", file: files[0]! };
-  }
-  const key = resolveEntry(entry, index);
-  if (key) return { kind: "symbol", key };
-  throw new Error(`Entrypoint not found: ${entry}`);
-}
-
-/**
- * Like {@link classifyEntrypoint}, but file identity is taken from the union of
- * both snapshots (so a path that exists on only one side still counts as a file).
- */
-export function classifyEntrypointAcross(
-  entry: string,
-  before: FunctionIndex,
-  after: FunctionIndex,
-): ClassifiedEntrypoint {
-  const files = matchEntrypointFiles(entry, [
-    ...indexedFiles(before),
-    ...indexedFiles(after),
-  ]);
-  if (files.length > 1) {
-    throw new Error(
-      `Ambiguous entrypoint file: ${entry} matches ${files.join(", ")}. Use a more specific path.`,
-    );
-  }
-  if (files.length === 1) {
-    return { kind: "file", file: files[0]! };
-  }
-  const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
-  if (key) return { kind: "symbol", key };
-  throw new Error(`Entrypoint not found: ${entry}`);
+  return matched[0]!;
 }
 
 /** Exported definitions in a concrete source path. */
@@ -95,22 +63,15 @@ export function exportsInFile(
 }
 
 /**
- * Exported definitions in the file matched by `entry`.
- * Throws when the path is ambiguous across multiple indexed files.
- * Returns [] when nothing matches (caller decides not-found vs no-exports).
+ * Exported definitions for a `--file` argument against one index.
+ * Throws when the path is missing/ambiguous; returns [] when the file has no exports.
  */
 export function resolveFileEntrypoints(
   entry: string,
   index: FunctionIndex,
 ): FunctionInfo[] {
-  const matched = matchEntrypointFiles(entry, indexedFiles(index));
-  if (matched.length === 0) return [];
-  if (matched.length > 1) {
-    throw new Error(
-      `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
-    );
-  }
-  return exportsInFile(matched[0]!, index);
+  const file = resolveEntrypointFile(entry, indexedFiles(index));
+  return exportsInFile(file, index);
 }
 
 function displayCallLabel(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,8 +99,12 @@ function emitAsciiOrData(
 
 const entryOption = z
   .union([z.string(), z.array(z.string())])
+  .describe("Entrypoint symbol(s): functionName or ClassName.method");
+
+const fileOption = z
+  .union([z.string(), z.array(z.string())])
   .describe(
-    "Entrypoint(s): functionName, ClassName.method, or an indexed source file path (expands to that file's exports)",
+    "Entrypoint file(s): indexed source path; expands to that file's exports",
   );
 
 const maxDepthOption = z.coerce
@@ -142,12 +146,13 @@ export const cli = Cli.create("calldiff", {
     }),
     options: z.object({
       entry: entryOption.optional(),
+      file: fileOption.optional(),
       maxDepth: maxDepthOption,
       locs: locsOption,
       from: z.string().optional().describe('Left / "before" tree'),
       to: z.string().optional().describe('Right / "after" tree'),
     }),
-    alias: { entry: "e" },
+    alias: { entry: "e", file: "F" },
     examples: [
       { description: "HEAD vs working tree" },
       {
@@ -164,9 +169,9 @@ export const cli = Cli.create("calldiff", {
         options: { entry: "createAgentSession" },
       },
       {
-        description: "File path as entrypoint (all exports in that file)",
+        description: "File as entrypoint (all exports in that file)",
         args: { from: "main", to: "feature" },
-        options: { entry: "src/routes.ts" },
+        options: { file: "src/routes.ts" },
       },
     ],
     usage: [
@@ -181,12 +186,14 @@ export const cli = Cli.create("calldiff", {
     hint: "Semantics match git diff: no refs → HEAD vs worktree; one ref → that vs worktree; two refs → compare those trees.",
     run(c) {
       const entries = entriesFromOption(c.options.entry);
+      const files = entriesFromOption(c.options.file);
       let result: DiffResult;
       try {
         result = runDiff({
           from: c.options.from ?? c.args.from,
           to: c.options.to ?? c.args.to,
           entries,
+          files,
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
           locs: c.options.locs,
@@ -226,11 +233,12 @@ export const cli = Cli.create("calldiff", {
       paths: pathsArg,
     }),
     options: z.object({
-      entry: entryOption,
+      entry: entryOption.optional(),
+      file: fileOption.optional(),
       maxDepth: maxDepthOption,
       locs: locsOption,
     }),
-    alias: { entry: "e" },
+    alias: { entry: "e", file: "F" },
     examples: [
       {
         description: "Tree from working tree",
@@ -243,15 +251,16 @@ export const cli = Cli.create("calldiff", {
       },
       {
         description: "Tree for every export in a file",
-        options: { entry: "packages/api/src/routes.ts" },
+        options: { file: "packages/api/src/routes.ts" },
       },
     ],
     run(c) {
       const entries = entriesFromOption(c.options.entry) ?? [];
-      if (entries.length === 0) {
+      const files = entriesFromOption(c.options.file) ?? [];
+      if (entries.length === 0 && files.length === 0) {
         return c.error({
           code: "MISSING_ENTRY",
-          message: "calldiff tree requires --entry / -e",
+          message: "calldiff tree requires --entry / -e or --file / -F",
           exitCode: 2,
         });
       }
@@ -260,6 +269,7 @@ export const cli = Cli.create("calldiff", {
         const result = runTree({
           ref: c.args.ref,
           entries,
+          files,
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
           locs: c.options.locs,
@@ -285,14 +295,15 @@ export const cli = Cli.create("calldiff", {
       paths: pathsArg,
     }),
     options: z.object({
-      entry: entryOption,
+      entry: entryOption.optional(),
+      file: fileOption.optional(),
       to: z
         .string()
         .describe("Target symbol to reach (functionName or ClassName.method)"),
       maxDepth: maxDepthOption,
       locs: locsOption,
     }),
-    alias: { entry: "e" },
+    alias: { entry: "e", file: "F" },
     examples: [
       {
         description: "Paths in the working tree",
@@ -303,13 +314,18 @@ export const cli = Cli.create("calldiff", {
         args: { ref: "HEAD", paths: ["examples/checkout"] },
         options: { entry: "runCheckout", to: "sendEmail" },
       },
+      {
+        description: "Paths from every export in a file",
+        options: { file: "packages/api/src/flow.ts", to: "notify" },
+      },
     ],
     run(c) {
       const entries = entriesFromOption(c.options.entry) ?? [];
-      if (entries.length === 0) {
+      const files = entriesFromOption(c.options.file) ?? [];
+      if (entries.length === 0 && files.length === 0) {
         return c.error({
           code: "MISSING_ENTRY",
-          message: "calldiff reach requires --entry / -e",
+          message: "calldiff reach requires --entry / -e or --file / -F",
           exitCode: 2,
         });
       }
@@ -325,6 +341,7 @@ export const cli = Cli.create("calldiff", {
         const result = runReach({
           ref: c.args.ref,
           entries,
+          files,
           to: c.options.to,
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ function emitAsciiOrData(
 const entryOption = z
   .union([z.string(), z.array(z.string())])
   .describe(
-    "Entrypoint(s): functionName, ClassName.method, or a source file path (expands to that file's exports)",
+    "Entrypoint(s): functionName, ClassName.method, or an indexed source file path (expands to that file's exports)",
   );
 
 const maxDepthOption = z.coerce

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,9 @@ function emitAsciiOrData(
 
 const entryOption = z
   .union([z.string(), z.array(z.string())])
-  .describe("Entrypoint(s): functionName or ClassName.method");
+  .describe(
+    "Entrypoint(s): functionName, ClassName.method, or a source file path (expands to that file's exports)",
+  );
 
 const maxDepthOption = z.coerce
   .number()
@@ -160,6 +162,11 @@ export const cli = Cli.create("calldiff", {
         description: "Force entrypoints",
         args: { from: "main", to: "feature" },
         options: { entry: "createAgentSession" },
+      },
+      {
+        description: "File path as entrypoint (all exports in that file)",
+        args: { from: "main", to: "feature" },
+        options: { entry: "src/routes.ts" },
       },
     ],
     usage: [
@@ -233,6 +240,10 @@ export const cli = Cli.create("calldiff", {
         description: "Tree from a commit",
         args: { ref: "HEAD" },
         options: { entry: "PiService.createAgentSession" },
+      },
+      {
+        description: "Tree for every export in a file",
+        options: { entry: "packages/api/src/routes.ts" },
       },
     ],
     run(c) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export { cli, normalizeArgv } from "./cli.js";
-export { buildCallTree, resolveAllEntries, resolveEntry } from "./calltree.js";
+export {
+  buildCallTree,
+  isFileEntrypoint,
+  matchEntrypointFiles,
+  normalizeEntryPath,
+  resolveAllEntries,
+  resolveEntry,
+  resolveFileEntrypoints,
+} from "./calltree.js";
 export { diffTrees, treeHasChanges } from "./diff.js";
 export { allFunctions, buildIndex, extractFunctions } from "./extract.js";
 export { formatSourceLoc, pickLoc } from "./loc.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 export { cli, normalizeArgv } from "./cli.js";
 export {
   buildCallTree,
-  isFileEntrypoint,
+  classifyEntrypoint,
+  classifyEntrypointAcross,
+  exportsInFile,
   matchEntrypointFiles,
   normalizeEntryPath,
   resolveAllEntries,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,12 @@
 export { cli, normalizeArgv } from "./cli.js";
 export {
   buildCallTree,
-  classifyEntrypoint,
-  classifyEntrypointAcross,
   exportsInFile,
   matchEntrypointFiles,
   normalizeEntryPath,
   resolveAllEntries,
   resolveEntry,
+  resolveEntrypointFile,
   resolveFileEntrypoints,
 } from "./calltree.js";
 export { diffTrees, treeHasChanges } from "./diff.js";

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -3,9 +3,10 @@ import { allFunctions, flattenCallKeys } from "./extract.js";
 import {
   buildCallTree,
   buildCallTreeFromInfo,
-  classifyEntrypointAcross,
   exportsInFile,
+  indexedFiles,
   resolveEntry,
+  resolveEntrypointFile,
 } from "./calltree.js";
 import { diffTrees, treeHasChanges } from "./diff.js";
 import type { DiffNode, FunctionInfo } from "./types.js";
@@ -79,29 +80,9 @@ function changedKeys(
     .sort((a, b) => a.localeCompare(b));
 }
 
-function fileExportsAcross(
-  file: string,
-  before: FunctionIndex,
-  after: FunctionIndex,
-): FunctionInfo[] {
-  const fromBefore = exportsInFile(file, before);
-  const fromAfter = exportsInFile(file, after);
-  if (fromBefore.length === 0 && fromAfter.length === 0) {
-    throw new Error(`No exported entrypoints in ${file}`);
-  }
-  const byKey = new Map<string, FunctionInfo>();
-  for (const info of [...fromBefore, ...fromAfter]) {
-    if (!byKey.has(info.key)) byKey.set(info.key, info);
-  }
-  return [...byKey.values()].sort((a, b) => {
-    if (a.label !== b.label) return a.label < b.label ? -1 : 1;
-    return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
-  });
-}
-
 /**
  * Infer entrypoints: exported functions whose expanded call trees differ,
- * plus any explicitly requested entries (symbols or indexed source files).
+ * plus any explicitly requested symbol entries.
  */
 export function inferEntries(
   before: FunctionIndex,
@@ -112,14 +93,9 @@ export function inferEntries(
   if (explicit.length > 0) {
     const entries: string[] = [];
     for (const entry of explicit) {
-      const classified = classifyEntrypointAcross(entry, before, after);
-      if (classified.kind === "file") {
-        for (const info of fileExportsAcross(classified.file, before, after)) {
-          if (!entries.includes(info.key)) entries.push(info.key);
-        }
-        continue;
-      }
-      if (!entries.includes(classified.key)) entries.push(classified.key);
+      const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
+      if (!key) throw new Error(`Entrypoint not found: ${entry}`);
+      if (!entries.includes(key)) entries.push(key);
     }
     return entries;
   }
@@ -138,63 +114,63 @@ export function inferEntries(
   return changedKeys(fallback, before, after, maxDepth);
 }
 
-/**
- * Expand explicit `-e` values into concrete definitions for diffing.
- * Indexed file paths pin to exported symbols in that file (both snapshots).
- */
-export function resolveExplicitDiffEntries(
-  before: FunctionIndex,
-  after: FunctionIndex,
-  explicit: string[],
-): Array<{
+export type ExplicitDiffEntry = {
   key: string;
   beforeInfo?: FunctionInfo;
   afterInfo?: FunctionInfo;
   /** When set, trees are built from these file-pinned definitions. */
   file?: string;
-}> {
-  const out: Array<{
-    key: string;
-    beforeInfo?: FunctionInfo;
-    afterInfo?: FunctionInfo;
-    file?: string;
-  }> = [];
+};
+
+/**
+ * Expand explicit `-e` symbols and `--file` paths into concrete diff roots.
+ */
+export function resolveExplicitDiffEntries(
+  before: FunctionIndex,
+  after: FunctionIndex,
+  symbols: string[],
+  files: string[] = [],
+): ExplicitDiffEntry[] {
+  const out: ExplicitDiffEntry[] = [];
   const seen = new Set<string>();
 
-  for (const entry of explicit) {
-    const classified = classifyEntrypointAcross(entry, before, after);
-    if (classified.kind === "file") {
-      const file = classified.file;
-      const keys = [
-        ...new Set(
-          [
-            ...exportsInFile(file, before),
-            ...exportsInFile(file, after),
-          ].map((info) => info.key),
-        ),
-      ].sort((a, b) => a.localeCompare(b));
-      if (keys.length === 0) {
-        throw new Error(`No exported entrypoints in ${file}`);
-      }
+  for (const entry of symbols) {
+    const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
+    if (!key) throw new Error(`Entrypoint not found: ${entry}`);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ key });
+  }
 
-      for (const key of keys) {
-        const id = `${file}\0${key}`;
-        if (seen.has(id)) continue;
-        seen.add(id);
-        const beforeInfo = allFunctions(before).find(
-          (fn) => fn.file === file && fn.key === key && fn.exported,
-        );
-        const afterInfo = allFunctions(after).find(
-          (fn) => fn.file === file && fn.key === key && fn.exported,
-        );
-        out.push({ key, beforeInfo, afterInfo, file });
-      }
-      continue;
+  for (const entry of files) {
+    const file = resolveEntrypointFile(entry, [
+      ...indexedFiles(before),
+      ...indexedFiles(after),
+    ]);
+    const keys = [
+      ...new Set(
+        [
+          ...exportsInFile(file, before),
+          ...exportsInFile(file, after),
+        ].map((info) => info.key),
+      ),
+    ].sort((a, b) => a.localeCompare(b));
+    if (keys.length === 0) {
+      throw new Error(`No exported entrypoints in ${file}`);
     }
 
-    if (seen.has(classified.key)) continue;
-    seen.add(classified.key);
-    out.push({ key: classified.key });
+    for (const key of keys) {
+      const id = `${file}\0${key}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const beforeInfo = allFunctions(before).find(
+        (fn) => fn.file === file && fn.key === key && fn.exported,
+      );
+      const afterInfo = allFunctions(after).find(
+        (fn) => fn.file === file && fn.key === key && fn.exported,
+      );
+      out.push({ key, beforeInfo, afterInfo, file });
+    }
   }
 
   return out;
@@ -230,13 +206,11 @@ export function diffEntry(
         children: [] as [],
       };
 
-  // If function only on one side, mark root accordingly via empty opposite
   if (!hasBefore && hasAfter) {
     const diff = diffTrees(
       { key: afterKey, label: afterTree.label, children: [] },
       afterTree,
     );
-    // Force root added
     return { ...diff, status: "added" };
   }
 

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -1,6 +1,13 @@
 import type { FunctionIndex } from "./extract.js";
-import { flattenCallKeys } from "./extract.js";
-import { buildCallTree, resolveEntry } from "./calltree.js";
+import { allFunctions, flattenCallKeys } from "./extract.js";
+import {
+  buildCallTree,
+  buildCallTreeFromInfo,
+  isFileEntrypoint,
+  matchEntrypointFiles,
+  resolveEntry,
+  resolveFileEntrypoints,
+} from "./calltree.js";
 import { diffTrees, treeHasChanges } from "./diff.js";
 import type { DiffNode, FunctionInfo } from "./types.js";
 
@@ -73,9 +80,51 @@ function changedKeys(
     .sort((a, b) => a.localeCompare(b));
 }
 
+function fileExistsInIndex(entry: string, index: FunctionIndex): string[] {
+  return matchEntrypointFiles(
+    entry,
+    allFunctions(index).map((fn) => fn.file),
+  );
+}
+
+function assertFileEntrypoints(
+  entry: string,
+  before: FunctionIndex,
+  after: FunctionIndex,
+): FunctionInfo[] {
+  const fromBefore = resolveFileEntrypoints(entry, before);
+  const fromAfter = resolveFileEntrypoints(entry, after);
+  if (fromBefore.length > 0 || fromAfter.length > 0) {
+    const byKey = new Map<string, FunctionInfo>();
+    for (const info of [...fromBefore, ...fromAfter]) {
+      if (!byKey.has(info.key)) byKey.set(info.key, info);
+    }
+    return [...byKey.values()].sort((a, b) => {
+      if (a.label !== b.label) return a.label < b.label ? -1 : 1;
+      return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+    });
+  }
+
+  const matched = [
+    ...new Set([
+      ...fileExistsInIndex(entry, before),
+      ...fileExistsInIndex(entry, after),
+    ]),
+  ].sort();
+  if (matched.length === 0) {
+    throw new Error(`Entrypoint file not found: ${entry}`);
+  }
+  if (matched.length > 1) {
+    throw new Error(
+      `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
+    );
+  }
+  throw new Error(`No exported entrypoints in ${matched[0]}`);
+}
+
 /**
  * Infer entrypoints: exported functions whose expanded call trees differ,
- * plus any explicitly requested entries.
+ * plus any explicitly requested entries (symbols or source file paths).
  */
 export function inferEntries(
   before: FunctionIndex,
@@ -86,6 +135,12 @@ export function inferEntries(
   if (explicit.length > 0) {
     const entries: string[] = [];
     for (const entry of explicit) {
+      if (isFileEntrypoint(entry)) {
+        for (const info of assertFileEntrypoints(entry, before, after)) {
+          if (!entries.includes(info.key)) entries.push(info.key);
+        }
+        continue;
+      }
       const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
       if (!key) throw new Error(`Entrypoint not found: ${entry}`);
       if (!entries.includes(key)) entries.push(key);
@@ -105,6 +160,72 @@ export function inferEntries(
   const checked = new Set(exported);
   const fallback = affected.filter((key) => !checked.has(key));
   return changedKeys(fallback, before, after, maxDepth);
+}
+
+/**
+ * Expand explicit `-e` values into concrete definitions for diffing.
+ * File paths pin to exported symbols in that file (both snapshots).
+ */
+export function resolveExplicitDiffEntries(
+  before: FunctionIndex,
+  after: FunctionIndex,
+  explicit: string[],
+): Array<{
+  key: string;
+  beforeInfo?: FunctionInfo;
+  afterInfo?: FunctionInfo;
+  /** When set, trees are built from these file-pinned definitions. */
+  file?: string;
+}> {
+  const out: Array<{
+    key: string;
+    beforeInfo?: FunctionInfo;
+    afterInfo?: FunctionInfo;
+    file?: string;
+  }> = [];
+  const seen = new Set<string>();
+
+  for (const entry of explicit) {
+    if (isFileEntrypoint(entry)) {
+      const infos = assertFileEntrypoints(entry, before, after);
+      const file =
+        infos[0]?.file ??
+        fileExistsInIndex(entry, after)[0] ??
+        fileExistsInIndex(entry, before)[0];
+      if (!file) throw new Error(`Entrypoint file not found: ${entry}`);
+
+      const keys = [
+        ...new Set(
+          [
+            ...resolveFileEntrypoints(entry, before),
+            ...resolveFileEntrypoints(entry, after),
+          ].map((info) => info.key),
+        ),
+      ].sort((a, b) => a.localeCompare(b));
+
+      for (const key of keys) {
+        const id = `${file}\0${key}`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const beforeInfo = allFunctions(before).find(
+          (fn) => fn.file === file && fn.key === key && fn.exported,
+        );
+        const afterInfo = allFunctions(after).find(
+          (fn) => fn.file === file && fn.key === key && fn.exported,
+        );
+        out.push({ key, beforeInfo, afterInfo, file });
+      }
+      continue;
+    }
+
+    const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
+    if (!key) throw new Error(`Entrypoint not found: ${entry}`);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ key });
+  }
+
+  return out;
 }
 
 export function diffEntry(
@@ -150,6 +271,55 @@ export function diffEntry(
   if (hasBefore && !hasAfter) {
     const diff = diffTrees(beforeTree, {
       key: beforeKey,
+      label: beforeTree.label,
+      children: [],
+    });
+    return { ...diff, status: "removed" };
+  }
+
+  const diff = diffTrees(beforeTree, afterTree);
+  if (!treeHasChanges(diff)) return null;
+  return diff;
+}
+
+/** Diff two file-pinned definitions (or missing on one side). */
+export function diffPinnedEntry(
+  key: string,
+  beforeInfo: FunctionInfo | undefined,
+  afterInfo: FunctionInfo | undefined,
+  before: FunctionIndex,
+  after: FunctionIndex,
+  maxDepth: number,
+): DiffNode | null {
+  if (!beforeInfo && !afterInfo) return null;
+
+  const beforeTree = beforeInfo
+    ? buildCallTreeFromInfo(beforeInfo, before, maxDepth)
+    : {
+        key,
+        label: afterInfo?.label ?? key,
+        children: [] as [],
+      };
+
+  const afterTree = afterInfo
+    ? buildCallTreeFromInfo(afterInfo, after, maxDepth)
+    : {
+        key,
+        label: beforeInfo?.label ?? key,
+        children: [] as [],
+      };
+
+  if (!beforeInfo && afterInfo) {
+    const diff = diffTrees(
+      { key, label: afterTree.label, children: [] },
+      afterTree,
+    );
+    return { ...diff, status: "added" };
+  }
+
+  if (beforeInfo && !afterInfo) {
+    const diff = diffTrees(beforeTree, {
+      key,
       label: beforeTree.label,
       children: [],
     });

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -3,10 +3,9 @@ import { allFunctions, flattenCallKeys } from "./extract.js";
 import {
   buildCallTree,
   buildCallTreeFromInfo,
-  isFileEntrypoint,
-  matchEntrypointFiles,
+  classifyEntrypointAcross,
+  exportsInFile,
   resolveEntry,
-  resolveFileEntrypoints,
 } from "./calltree.js";
 import { diffTrees, treeHasChanges } from "./diff.js";
 import type { DiffNode, FunctionInfo } from "./types.js";
@@ -80,51 +79,29 @@ function changedKeys(
     .sort((a, b) => a.localeCompare(b));
 }
 
-function fileExistsInIndex(entry: string, index: FunctionIndex): string[] {
-  return matchEntrypointFiles(
-    entry,
-    allFunctions(index).map((fn) => fn.file),
-  );
-}
-
-function assertFileEntrypoints(
-  entry: string,
+function fileExportsAcross(
+  file: string,
   before: FunctionIndex,
   after: FunctionIndex,
 ): FunctionInfo[] {
-  const fromBefore = resolveFileEntrypoints(entry, before);
-  const fromAfter = resolveFileEntrypoints(entry, after);
-  if (fromBefore.length > 0 || fromAfter.length > 0) {
-    const byKey = new Map<string, FunctionInfo>();
-    for (const info of [...fromBefore, ...fromAfter]) {
-      if (!byKey.has(info.key)) byKey.set(info.key, info);
-    }
-    return [...byKey.values()].sort((a, b) => {
-      if (a.label !== b.label) return a.label < b.label ? -1 : 1;
-      return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
-    });
+  const fromBefore = exportsInFile(file, before);
+  const fromAfter = exportsInFile(file, after);
+  if (fromBefore.length === 0 && fromAfter.length === 0) {
+    throw new Error(`No exported entrypoints in ${file}`);
   }
-
-  const matched = [
-    ...new Set([
-      ...fileExistsInIndex(entry, before),
-      ...fileExistsInIndex(entry, after),
-    ]),
-  ].sort();
-  if (matched.length === 0) {
-    throw new Error(`Entrypoint file not found: ${entry}`);
+  const byKey = new Map<string, FunctionInfo>();
+  for (const info of [...fromBefore, ...fromAfter]) {
+    if (!byKey.has(info.key)) byKey.set(info.key, info);
   }
-  if (matched.length > 1) {
-    throw new Error(
-      `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
-    );
-  }
-  throw new Error(`No exported entrypoints in ${matched[0]}`);
+  return [...byKey.values()].sort((a, b) => {
+    if (a.label !== b.label) return a.label < b.label ? -1 : 1;
+    return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  });
 }
 
 /**
  * Infer entrypoints: exported functions whose expanded call trees differ,
- * plus any explicitly requested entries (symbols or source file paths).
+ * plus any explicitly requested entries (symbols or indexed source files).
  */
 export function inferEntries(
   before: FunctionIndex,
@@ -135,15 +112,14 @@ export function inferEntries(
   if (explicit.length > 0) {
     const entries: string[] = [];
     for (const entry of explicit) {
-      if (isFileEntrypoint(entry)) {
-        for (const info of assertFileEntrypoints(entry, before, after)) {
+      const classified = classifyEntrypointAcross(entry, before, after);
+      if (classified.kind === "file") {
+        for (const info of fileExportsAcross(classified.file, before, after)) {
           if (!entries.includes(info.key)) entries.push(info.key);
         }
         continue;
       }
-      const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
-      if (!key) throw new Error(`Entrypoint not found: ${entry}`);
-      if (!entries.includes(key)) entries.push(key);
+      if (!entries.includes(classified.key)) entries.push(classified.key);
     }
     return entries;
   }
@@ -164,7 +140,7 @@ export function inferEntries(
 
 /**
  * Expand explicit `-e` values into concrete definitions for diffing.
- * File paths pin to exported symbols in that file (both snapshots).
+ * Indexed file paths pin to exported symbols in that file (both snapshots).
  */
 export function resolveExplicitDiffEntries(
   before: FunctionIndex,
@@ -186,22 +162,20 @@ export function resolveExplicitDiffEntries(
   const seen = new Set<string>();
 
   for (const entry of explicit) {
-    if (isFileEntrypoint(entry)) {
-      const infos = assertFileEntrypoints(entry, before, after);
-      const file =
-        infos[0]?.file ??
-        fileExistsInIndex(entry, after)[0] ??
-        fileExistsInIndex(entry, before)[0];
-      if (!file) throw new Error(`Entrypoint file not found: ${entry}`);
-
+    const classified = classifyEntrypointAcross(entry, before, after);
+    if (classified.kind === "file") {
+      const file = classified.file;
       const keys = [
         ...new Set(
           [
-            ...resolveFileEntrypoints(entry, before),
-            ...resolveFileEntrypoints(entry, after),
+            ...exportsInFile(file, before),
+            ...exportsInFile(file, after),
           ].map((info) => info.key),
         ),
       ].sort((a, b) => a.localeCompare(b));
+      if (keys.length === 0) {
+        throw new Error(`No exported entrypoints in ${file}`);
+      }
 
       for (const key of keys) {
         const id = `${file}\0${key}`;
@@ -218,11 +192,9 @@ export function resolveExplicitDiffEntries(
       continue;
     }
 
-    const key = resolveEntry(entry, after) ?? resolveEntry(entry, before);
-    if (!key) throw new Error(`Entrypoint not found: ${entry}`);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push({ key });
+    if (seen.has(classified.key)) continue;
+    seen.add(classified.key);
+    out.push({ key: classified.key });
   }
 
   return out;

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,11 +1,10 @@
 import {
   buildCallTreeFromInfo,
-  isFileEntrypoint,
-  matchEntrypointFiles,
+  classifyEntrypoint,
+  exportsInFile,
   resolveEntry,
-  resolveFileEntrypoints,
 } from "./calltree.js";
-import { allFunctions, buildIndex, extractCached } from "./extract.js";
+import { buildIndex, extractCached } from "./extract.js";
 import {
   assertGitRepo,
   describeSnapshot,
@@ -114,8 +113,8 @@ function loadIndex(
 }
 
 /**
- * Resolve `-e` symbols and file paths to concrete definitions.
- * File paths expand to every exported symbol defined in that file.
+ * Resolve `-e` values to concrete definitions.
+ * Indexed file paths expand to every exported symbol defined in that file.
  */
 function resolveEntrypointInfos(
   index: FunctionIndex,
@@ -125,22 +124,11 @@ function resolveEntrypointInfos(
   const seen = new Set<string>();
 
   for (const entry of explicit) {
-    if (isFileEntrypoint(entry)) {
-      const infos = resolveFileEntrypoints(entry, index);
+    const classified = classifyEntrypoint(entry, index);
+    if (classified.kind === "file") {
+      const infos = exportsInFile(classified.file, index);
       if (infos.length === 0) {
-        const matched = matchEntrypointFiles(
-          entry,
-          allFunctions(index).map((fn) => fn.file),
-        );
-        if (matched.length === 0) {
-          throw new Error(`Entrypoint file not found: ${entry}`);
-        }
-        if (matched.length > 1) {
-          throw new Error(
-            `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
-          );
-        }
-        throw new Error(`No exported entrypoints in ${matched[0]}`);
+        throw new Error(`No exported entrypoints in ${classified.file}`);
       }
       for (const info of infos) {
         const id = `${info.file}\0${info.key}\0${info.line ?? ""}`;
@@ -151,11 +139,7 @@ function resolveEntrypointInfos(
       continue;
     }
 
-    const key = resolveEntry(entry, index);
-    if (!key) {
-      throw new Error(`Entrypoint not found: ${entry}`);
-    }
-    const info = index.get(key);
+    const info = index.get(classified.key);
     if (!info) {
       throw new Error(`Entrypoint not found: ${entry}`);
     }
@@ -372,8 +356,12 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const entryKeys: string[] = [];
 
   for (const entry of options.entries) {
-    if (isFileEntrypoint(entry)) {
-      const infos = resolveEntrypointInfos(index, [entry]);
+    const classified = classifyEntrypoint(entry, index);
+    if (classified.kind === "file") {
+      const infos = exportsInFile(classified.file, index);
+      if (infos.length === 0) {
+        throw new Error(`No exported entrypoints in ${classified.file}`);
+      }
       for (const info of infos) {
         if (!entryKeys.includes(info.key)) entryKeys.push(info.key);
         const tree = buildCallTreeFromInfo(info, index, maxDepth);
@@ -387,11 +375,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
       continue;
     }
 
-    const key = resolveEntry(entry, index);
-    if (!key) {
-      throw new Error(`Entrypoint not found: ${entry}`);
-    }
-    if (!entryKeys.includes(key)) entryKeys.push(key);
+    if (!entryKeys.includes(classified.key)) entryKeys.push(classified.key);
     const found = findReachPaths(entry, targetKey, index, maxDepth);
     for (const path of found) {
       pathResults.push({

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,8 +1,9 @@
 import {
   buildCallTreeFromInfo,
-  classifyEntrypoint,
   exportsInFile,
   resolveEntry,
+  resolveEntrypointFile,
+  indexedFiles,
 } from "./calltree.js";
 import { buildIndex, extractCached } from "./extract.js";
 import {
@@ -38,7 +39,10 @@ import type {
 export type DiffRunOptions = {
   from?: string;
   to?: string;
+  /** Symbol entrypoints (`-e`). */
   entries?: string[];
+  /** File entrypoints (`--file`): expand to that file's exports. */
+  files?: string[];
   paths?: string[];
   cwd?: string;
   maxDepth?: number;
@@ -50,7 +54,8 @@ export type DiffRunOptions = {
 
 export type TreeRunOptions = {
   ref?: string;
-  entries: string[];
+  entries?: string[];
+  files?: string[];
   paths?: string[];
   cwd?: string;
   maxDepth?: number;
@@ -61,7 +66,9 @@ export type TreeRunOptions = {
 export type ReachRunOptions = {
   ref?: string;
   /** Start symbol(s). */
-  entries: string[];
+  entries?: string[];
+  /** Start file(s): every export in the file. */
+  files?: string[];
   /** Target symbol to reach. */
   to: string;
   paths?: string[];
@@ -112,34 +119,20 @@ function loadIndex(
   return buildIndex(functions);
 }
 
-/**
- * Resolve `-e` values to concrete definitions.
- * Indexed file paths expand to every exported symbol defined in that file.
- */
-function resolveEntrypointInfos(
+/** Resolve `-e` symbols to concrete definitions. */
+function resolveSymbolInfos(
   index: FunctionIndex,
-  explicit: string[],
+  symbols: string[],
 ): FunctionInfo[] {
   const resolved: FunctionInfo[] = [];
   const seen = new Set<string>();
 
-  for (const entry of explicit) {
-    const classified = classifyEntrypoint(entry, index);
-    if (classified.kind === "file") {
-      const infos = exportsInFile(classified.file, index);
-      if (infos.length === 0) {
-        throw new Error(`No exported entrypoints in ${classified.file}`);
-      }
-      for (const info of infos) {
-        const id = `${info.file}\0${info.key}\0${info.line ?? ""}`;
-        if (seen.has(id)) continue;
-        seen.add(id);
-        resolved.push(info);
-      }
-      continue;
+  for (const entry of symbols) {
+    const key = resolveEntry(entry, index);
+    if (!key) {
+      throw new Error(`Entrypoint not found: ${entry}`);
     }
-
-    const info = index.get(classified.key);
+    const info = index.get(key);
     if (!info) {
       throw new Error(`Entrypoint not found: ${entry}`);
     }
@@ -150,6 +143,42 @@ function resolveEntrypointInfos(
   }
 
   return resolved;
+}
+
+/** Resolve `--file` paths to exported definitions (file-pinned). */
+function resolveFileInfos(
+  index: FunctionIndex,
+  files: string[],
+): FunctionInfo[] {
+  const resolved: FunctionInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of files) {
+    const file = resolveEntrypointFile(entry, indexedFiles(index));
+    const infos = exportsInFile(file, index);
+    if (infos.length === 0) {
+      throw new Error(`No exported entrypoints in ${file}`);
+    }
+    for (const info of infos) {
+      const id = `${info.file}\0${info.key}\0${info.line ?? ""}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      resolved.push(info);
+    }
+  }
+
+  return resolved;
+}
+
+function resolveEntrypointInfos(
+  index: FunctionIndex,
+  symbols: string[],
+  files: string[],
+): FunctionInfo[] {
+  return [
+    ...resolveSymbolInfos(index, symbols),
+    ...resolveFileInfos(index, files),
+  ];
 }
 
 function serializeCallNode(node: CallNode): CallNode {
@@ -182,8 +211,10 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   const cwd = options.cwd ?? process.cwd();
   const maxDepth = options.maxDepth ?? 12;
   const entriesOpt = options.entries ?? [];
+  const filesOpt = options.files ?? [];
   const color = options.color !== false;
   const locs = options.locs === true;
+  const hasExplicit = entriesOpt.length > 0 || filesOpt.length > 0;
 
   assertGitRepo(cwd);
 
@@ -225,8 +256,13 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
     asciiParts.push(ascii);
   };
 
-  if (entriesOpt.length > 0) {
-    const explicit = resolveExplicitDiffEntries(before, after, entriesOpt);
+  if (hasExplicit) {
+    const explicit = resolveExplicitDiffEntries(
+      before,
+      after,
+      entriesOpt,
+      filesOpt,
+    );
     for (const item of explicit) {
       const diff = item.file
         ? diffPinnedEntry(
@@ -263,10 +299,9 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   }
 
   if (trees.length === 0) {
-    const message =
-      entriesOpt.length > 0
-        ? "No callstack changes for requested entrypoints."
-        : "No callstack changes for inferred entrypoints.";
+    const message = hasExplicit
+      ? "No callstack changes for requested entrypoints."
+      : "No callstack changes for inferred entrypoints.";
     return {
       mode: "diff",
       from: fromLabel,
@@ -292,6 +327,8 @@ export function runTree(options: TreeRunOptions): TreeResult {
   const maxDepth = options.maxDepth ?? 12;
   const color = options.color !== false;
   const locs = options.locs === true;
+  const symbols = options.entries ?? [];
+  const files = options.files ?? [];
 
   assertGitRepo(cwd);
 
@@ -303,7 +340,7 @@ export function runTree(options: TreeRunOptions): TreeResult {
   if (snapshot.kind === "commit") verifyCommit(cwd, snapshot.ref);
 
   const index = loadIndex(cwd, snapshot, paths);
-  const infos = resolveEntrypointInfos(index, options.entries);
+  const infos = resolveEntrypointInfos(index, symbols, files);
   const refLabel = describeSnapshot(snapshot);
 
   const trees: TreeResult["trees"] = [];
@@ -335,6 +372,8 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const maxDepth = options.maxDepth ?? 12;
   const color = options.color !== false;
   const locs = options.locs === true;
+  const symbols = options.entries ?? [];
+  const files = options.files ?? [];
 
   assertGitRepo(cwd);
 
@@ -355,29 +394,25 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const pathResults: ReachResult["paths"] = [];
   const entryKeys: string[] = [];
 
-  for (const entry of options.entries) {
-    const classified = classifyEntrypoint(entry, index);
-    if (classified.kind === "file") {
-      const infos = exportsInFile(classified.file, index);
-      if (infos.length === 0) {
-        throw new Error(`No exported entrypoints in ${classified.file}`);
-      }
-      for (const info of infos) {
-        if (!entryKeys.includes(info.key)) entryKeys.push(info.key);
-        const tree = buildCallTreeFromInfo(info, index, maxDepth);
-        for (const path of collectPathsTo(tree, targetKey, options.to)) {
-          pathResults.push({
-            ascii: renderTree(path, { color: false, locs }),
-            tree: serializeCallNode(path),
-          });
-        }
-      }
-      continue;
+  for (const entry of symbols) {
+    const key = resolveEntry(entry, index);
+    if (!key) {
+      throw new Error(`Entrypoint not found: ${entry}`);
     }
-
-    if (!entryKeys.includes(classified.key)) entryKeys.push(classified.key);
+    if (!entryKeys.includes(key)) entryKeys.push(key);
     const found = findReachPaths(entry, targetKey, index, maxDepth);
     for (const path of found) {
+      pathResults.push({
+        ascii: renderTree(path, { color: false, locs }),
+        tree: serializeCallNode(path),
+      });
+    }
+  }
+
+  for (const info of resolveFileInfos(index, files)) {
+    if (!entryKeys.includes(info.key)) entryKeys.push(info.key);
+    const tree = buildCallTreeFromInfo(info, index, maxDepth);
+    for (const path of collectPathsTo(tree, targetKey, options.to)) {
       pathResults.push({
         ascii: renderTree(path, { color: false, locs }),
         tree: serializeCallNode(path),

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,11 @@
-import { buildCallTree, resolveEntry } from "./calltree.js";
-import { buildIndex, extractCached } from "./extract.js";
+import {
+  buildCallTreeFromInfo,
+  isFileEntrypoint,
+  matchEntrypointFiles,
+  resolveEntry,
+  resolveFileEntrypoints,
+} from "./calltree.js";
+import { allFunctions, buildIndex, extractCached } from "./extract.js";
 import {
   assertGitRepo,
   describeSnapshot,
@@ -10,8 +16,13 @@ import {
   visitCommitBlobs,
   visitWorktreeFiles,
 } from "./git.js";
-import { diffEntry, inferEntries } from "./infer.js";
-import { findReachPaths } from "./reach.js";
+import {
+  diffEntry,
+  diffPinnedEntry,
+  inferEntries,
+  resolveExplicitDiffEntries,
+} from "./infer.js";
+import { collectPathsTo, findReachPaths } from "./reach.js";
 import { renderDiff, renderTree } from "./render.js";
 import type { ExtractionCache, FunctionIndex } from "./extract.js";
 import type { SnapshotFile } from "./git.js";
@@ -102,15 +113,58 @@ function loadIndex(
   return buildIndex(functions);
 }
 
-function resolveEntries(index: FunctionIndex, explicit: string[]): string[] {
-  const resolved: string[] = [];
+/**
+ * Resolve `-e` symbols and file paths to concrete definitions.
+ * File paths expand to every exported symbol defined in that file.
+ */
+function resolveEntrypointInfos(
+  index: FunctionIndex,
+  explicit: string[],
+): FunctionInfo[] {
+  const resolved: FunctionInfo[] = [];
+  const seen = new Set<string>();
+
   for (const entry of explicit) {
+    if (isFileEntrypoint(entry)) {
+      const infos = resolveFileEntrypoints(entry, index);
+      if (infos.length === 0) {
+        const matched = matchEntrypointFiles(
+          entry,
+          allFunctions(index).map((fn) => fn.file),
+        );
+        if (matched.length === 0) {
+          throw new Error(`Entrypoint file not found: ${entry}`);
+        }
+        if (matched.length > 1) {
+          throw new Error(
+            `Ambiguous entrypoint file: ${entry} matches ${matched.join(", ")}. Use a more specific path.`,
+          );
+        }
+        throw new Error(`No exported entrypoints in ${matched[0]}`);
+      }
+      for (const info of infos) {
+        const id = `${info.file}\0${info.key}\0${info.line ?? ""}`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        resolved.push(info);
+      }
+      continue;
+    }
+
     const key = resolveEntry(entry, index);
     if (!key) {
       throw new Error(`Entrypoint not found: ${entry}`);
     }
-    if (!resolved.includes(key)) resolved.push(key);
+    const info = index.get(key);
+    if (!info) {
+      throw new Error(`Entrypoint not found: ${entry}`);
+    }
+    const id = `${info.file}\0${info.key}\0${info.line ?? ""}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    resolved.push(info);
   }
+
   return resolved;
 }
 
@@ -167,22 +221,8 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   const after = loadIndex(cwd, to, resolvedPaths, extractionCache);
   extractionCache.clear();
 
-  const entries = inferEntries(before, after, entriesOpt, maxDepth);
-
   const fromLabel = describeSnapshot(from);
   const toLabel = describeSnapshot(to);
-
-  if (entries.length === 0) {
-    const message = `No callstack changes between ${fromLabel} and ${toLabel}.`;
-    return {
-      mode: "diff",
-      from: fromLabel,
-      to: toLabel,
-      message,
-      trees: [],
-      ascii: message,
-    };
-  }
 
   const trees: DiffResult["trees"] = [];
   const asciiParts: string[] = [
@@ -190,9 +230,7 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
     "",
   ];
 
-  for (const entry of entries) {
-    const diff = diffEntry(entry, before, after, maxDepth);
-    if (!diff) continue;
+  const pushDiff = (entry: string, diff: DiffNode): void => {
     const ascii = renderDiff(diff, { color, locs });
     trees.push({
       entry,
@@ -201,10 +239,50 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
     });
     if (asciiParts.length > 2) asciiParts.push("");
     asciiParts.push(ascii);
+  };
+
+  if (entriesOpt.length > 0) {
+    const explicit = resolveExplicitDiffEntries(before, after, entriesOpt);
+    for (const item of explicit) {
+      const diff = item.file
+        ? diffPinnedEntry(
+            item.key,
+            item.beforeInfo,
+            item.afterInfo,
+            before,
+            after,
+            maxDepth,
+          )
+        : diffEntry(item.key, before, after, maxDepth);
+      if (!diff) continue;
+      pushDiff(item.key, diff);
+    }
+  } else {
+    const entries = inferEntries(before, after, [], maxDepth);
+    if (entries.length === 0) {
+      const message = `No callstack changes between ${fromLabel} and ${toLabel}.`;
+      return {
+        mode: "diff",
+        from: fromLabel,
+        to: toLabel,
+        message,
+        trees: [],
+        ascii: message,
+      };
+    }
+
+    for (const entry of entries) {
+      const diff = diffEntry(entry, before, after, maxDepth);
+      if (!diff) continue;
+      pushDiff(entry, diff);
+    }
   }
 
   if (trees.length === 0) {
-    const message = "No callstack changes for inferred entrypoints.";
+    const message =
+      entriesOpt.length > 0
+        ? "No callstack changes for requested entrypoints."
+        : "No callstack changes for inferred entrypoints.";
     return {
       mode: "diff",
       from: fromLabel,
@@ -241,17 +319,17 @@ export function runTree(options: TreeRunOptions): TreeResult {
   if (snapshot.kind === "commit") verifyCommit(cwd, snapshot.ref);
 
   const index = loadIndex(cwd, snapshot, paths);
-  const entries = resolveEntries(index, options.entries);
+  const infos = resolveEntrypointInfos(index, options.entries);
   const refLabel = describeSnapshot(snapshot);
 
   const trees: TreeResult["trees"] = [];
   const asciiParts: string[] = [`calldiff tree ${refLabel}`, ""];
 
-  for (const entry of entries) {
-    const tree = buildCallTree(entry, index, maxDepth);
+  for (const info of infos) {
+    const tree = buildCallTreeFromInfo(info, index, maxDepth);
     const ascii = renderTree(tree, { color, locs });
     trees.push({
-      entry,
+      entry: info.key,
       ascii: renderTree(tree, { color: false, locs }),
       tree: serializeCallNode(tree),
     });
@@ -284,7 +362,6 @@ export function runReach(options: ReachRunOptions): ReachResult {
   if (snapshot.kind === "commit") verifyCommit(cwd, snapshot.ref);
 
   const index = loadIndex(cwd, snapshot, paths);
-  const entries = resolveEntries(index, options.entries);
   const targetKey = resolveEntry(options.to, index);
   if (!targetKey) {
     throw new Error(`Target not found: ${options.to}`);
@@ -292,7 +369,29 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const refLabel = describeSnapshot(snapshot);
 
   const pathResults: ReachResult["paths"] = [];
-  for (const entry of entries) {
+  const entryKeys: string[] = [];
+
+  for (const entry of options.entries) {
+    if (isFileEntrypoint(entry)) {
+      const infos = resolveEntrypointInfos(index, [entry]);
+      for (const info of infos) {
+        if (!entryKeys.includes(info.key)) entryKeys.push(info.key);
+        const tree = buildCallTreeFromInfo(info, index, maxDepth);
+        for (const path of collectPathsTo(tree, targetKey, options.to)) {
+          pathResults.push({
+            ascii: renderTree(path, { color: false, locs }),
+            tree: serializeCallNode(path),
+          });
+        }
+      }
+      continue;
+    }
+
+    const key = resolveEntry(entry, index);
+    if (!key) {
+      throw new Error(`Entrypoint not found: ${entry}`);
+    }
+    if (!entryKeys.includes(key)) entryKeys.push(key);
     const found = findReachPaths(entry, targetKey, index, maxDepth);
     for (const path of found) {
       pathResults.push({
@@ -303,7 +402,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
   }
 
   const fromLabel =
-    entries.length === 1 ? entries[0]! : entries.join(", ");
+    entryKeys.length === 1 ? entryKeys[0]! : entryKeys.join(", ");
   const header = `calldiff reach ${refLabel}: ${fromLabel} → ${targetKey}`;
 
   if (pathResults.length === 0) {

--- a/test/file-entry.test.ts
+++ b/test/file-entry.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "vitest";
+import { outdent } from "outdent";
+import {
+  isFileEntrypoint,
+  matchEntrypointFiles,
+  resolveFileEntrypoints,
+} from "../src/calltree.js";
+import { buildIndex } from "../src/extract.js";
+import { inferEntries } from "../src/infer.js";
+import type { FunctionInfo } from "../src/types.js";
+import { workspace } from "./workspace.js";
+
+const src = outdent({ trimTrailingNewline: false });
+
+function fn(
+  key: string,
+  file: string,
+  calls: string[] = [],
+  exported = true,
+): FunctionInfo {
+  return {
+    key,
+    label: `${key}()`,
+    file,
+    steps: calls.map((call) => ({ type: "call", key: call })),
+    exported,
+    start: 0,
+    end: 1,
+  };
+}
+
+describe("file entrypoint detection", () => {
+  test("treats paths and source extensions as files", () => {
+    expect(isFileEntrypoint("src/routes.ts")).toBe(true);
+    expect(isFileEntrypoint("./packages/api/src/boot.ts")).toBe(true);
+    expect(isFileEntrypoint("routes.ts")).toBe(true);
+    expect(isFileEntrypoint("app.py")).toBe(true);
+  });
+
+  test("leaves symbol names alone", () => {
+    expect(isFileEntrypoint("createAgentSession")).toBe(false);
+    expect(isFileEntrypoint("PiService.createAgentSession")).toBe(false);
+    expect(isFileEntrypoint("new Foo")).toBe(false);
+  });
+});
+
+describe("file entrypoint matching", () => {
+  test("prefers exact paths then unique suffixes", () => {
+    expect(
+      matchEntrypointFiles("src/routes.ts", [
+        "src/routes.ts",
+        "packages/api/src/routes.ts",
+      ]),
+    ).toEqual(["src/routes.ts"]);
+
+    expect(
+      matchEntrypointFiles("routes.ts", [
+        "packages/api/src/routes.ts",
+      ]),
+    ).toEqual(["packages/api/src/routes.ts"]);
+  });
+
+  test("lists every ambiguous suffix match", () => {
+    expect(
+      matchEntrypointFiles("routes.ts", [
+        "packages/a/src/routes.ts",
+        "packages/b/src/routes.ts",
+      ]),
+    ).toEqual(["packages/a/src/routes.ts", "packages/b/src/routes.ts"]);
+  });
+
+  test("resolveFileEntrypoints returns exported defs only", () => {
+    const index = buildIndex([
+      fn("boot", "src/boot.ts", ["run"], true),
+      fn("run", "src/boot.ts", [], false),
+      fn("other", "src/other.ts", [], true),
+    ]);
+
+    expect(resolveFileEntrypoints("boot.ts", index).map((i) => i.key)).toEqual([
+      "boot",
+    ]);
+  });
+
+  test("resolveFileEntrypoints rejects ambiguous paths", () => {
+    const index = buildIndex([
+      fn("boot", "packages/a/src/boot.ts", [], true),
+      fn("boot", "packages/b/src/boot.ts", [], true),
+    ]);
+
+    expect(() => resolveFileEntrypoints("boot.ts", index)).toThrow(
+      /Ambiguous entrypoint file/,
+    );
+  });
+});
+
+describe("inferEntries with file paths", () => {
+  test("expands a file path to exported keys", () => {
+    const before = buildIndex([
+      fn("boot", "src/boot.ts", ["old"], true),
+      fn("helper", "src/boot.ts", [], false),
+    ]);
+    const after = buildIndex([
+      fn("boot", "src/boot.ts", ["new"], true),
+      fn("helper", "src/boot.ts", [], false),
+    ]);
+
+    expect(inferEntries(before, after, ["src/boot.ts"], 12)).toEqual(["boot"]);
+  });
+});
+
+describe("CLI file entrypoints", () => {
+  test("tree -e <file> expands exported symbols in that file", () => {
+    const host = workspace({
+      "/packages/api/src/boot.ts": src`
+        export function boot() {
+          run();
+        }
+        function run() {}
+        export function ready() {
+          ping();
+        }
+        function ping() {}
+      `,
+      "/packages/api/src/other.ts": src`
+        export function decoy() {
+          boom();
+        }
+        function boom() {}
+      `,
+    });
+
+    const result = host.run("calldiff tree -e packages/api/src/boot.ts");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("boot()");
+    expect(result.stdout).toContain("run()");
+    expect(result.stdout).toContain("ready()");
+    expect(result.stdout).toContain("ping()");
+    expect(result.stdout).not.toContain("decoy()");
+  });
+
+  test("tree -e pins to the file when the same name exists elsewhere", () => {
+    const host = workspace({
+      "/packages/a/src/flow.ts": src`
+        export function start() {
+          fromA();
+        }
+        function fromA() {}
+      `,
+      "/packages/b/src/flow.ts": src`
+        export function start() {
+          fromB();
+        }
+        function fromB() {}
+      `,
+    });
+
+    const result = host.run("calldiff tree -e packages/b/src/flow.ts");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("fromB()");
+    expect(result.stdout).not.toContain("fromA()");
+  });
+
+  test("reach -e <file> walks exports in that file only", () => {
+    const host = workspace({
+      "/packages/a/src/flow.ts": src`
+        export function start() {
+          notify();
+        }
+      `,
+      "/packages/b/src/flow.ts": src`
+        export function start() {
+          other();
+        }
+        function other() {}
+      `,
+      "/packages/a/src/notify.ts": src`
+        export function notify() {}
+      `,
+    });
+
+    const result = host.run(
+      "calldiff reach -e packages/a/src/flow.ts --to notify",
+    );
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("notify()");
+    expect(result.stdout).not.toContain("other()");
+  });
+
+  test("diff -e <file> diffs exports defined in that file", () => {
+    const host = workspace();
+    const before = host.commit("before", {
+      "/src/boot.ts": src`
+        export function boot() {
+          oldPath();
+        }
+        function oldPath() {}
+      `,
+    });
+    host.commit("after", {
+      "/src/boot.ts": src`
+        export function boot() {
+          newPath();
+        }
+        function newPath() {}
+      `,
+    });
+
+    const result = host.run(`calldiff diff ${before} HEAD -e src/boot.ts`);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("boot()");
+    expect(result.stdout).toContain("oldPath()");
+    expect(result.stdout).toContain("newPath()");
+    expect(result.stdout).toMatch(/^- /m);
+    expect(result.stdout).toMatch(/^\+ /m);
+  }, 30_000);
+
+  test("errors when a file entrypoint is ambiguous", () => {
+    const host = workspace({
+      "/packages/a/src/boot.ts": src`
+        export function boot() {}
+      `,
+      "/packages/b/src/boot.ts": src`
+        export function boot() {}
+      `,
+    });
+
+    const result = host.run("calldiff tree -e boot.ts");
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(
+      /Ambiguous entrypoint file/,
+    );
+  });
+
+  test("errors when a file has no exported entrypoints", () => {
+    const host = workspace({
+      "/src/internal.ts": src`
+        function helper() {
+          work();
+        }
+        function work() {}
+      `,
+    });
+
+    const result = host.run("calldiff tree -e src/internal.ts");
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(
+      /No exported entrypoints/,
+    );
+  });
+});

--- a/test/file-entry.test.ts
+++ b/test/file-entry.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
 import { outdent } from "outdent";
 import {
-  classifyEntrypoint,
   matchEntrypointFiles,
+  resolveEntrypointFile,
   resolveFileEntrypoints,
 } from "../src/calltree.js";
 import { buildIndex } from "../src/extract.js";
-import { inferEntries } from "../src/infer.js";
+import { resolveExplicitDiffEntries } from "../src/infer.js";
 import type { FunctionInfo } from "../src/types.js";
 import { workspace } from "./workspace.js";
 
@@ -28,40 +28,6 @@ function fn(
     end: 1,
   };
 }
-
-describe("entrypoint classification", () => {
-  test("classifies by indexed file lookup, not string shape", () => {
-    const index = buildIndex([
-      fn("boot", "src/boot.ts", ["run"], true),
-      fn("run", "src/boot.ts", [], false),
-    ]);
-
-    expect(classifyEntrypoint("src/boot.ts", index)).toEqual({
-      kind: "file",
-      file: "src/boot.ts",
-    });
-    expect(classifyEntrypoint("boot.ts", index)).toEqual({
-      kind: "file",
-      file: "src/boot.ts",
-    });
-    expect(classifyEntrypoint("boot", index)).toEqual({
-      kind: "symbol",
-      key: "boot",
-    });
-  });
-
-  test("path-shaped strings that are not indexed stay symbols / not-found", () => {
-    const index = buildIndex([fn("boot", "src/boot.ts", [], true)]);
-
-    expect(classifyEntrypoint("boot", index).kind).toBe("symbol");
-    expect(() => classifyEntrypoint("src/missing.ts", index)).toThrow(
-      /Entrypoint not found/,
-    );
-    expect(() => classifyEntrypoint("packages/api/src/routes.ts", index)).toThrow(
-      /Entrypoint not found/,
-    );
-  });
-});
 
 describe("file entrypoint matching", () => {
   test("prefers exact paths then unique suffixes", () => {
@@ -88,6 +54,12 @@ describe("file entrypoint matching", () => {
     ).toEqual(["packages/a/src/routes.ts", "packages/b/src/routes.ts"]);
   });
 
+  test("resolveEntrypointFile throws when missing", () => {
+    expect(() => resolveEntrypointFile("missing.ts", ["src/boot.ts"])).toThrow(
+      /Entrypoint file not found/,
+    );
+  });
+
   test("resolveFileEntrypoints returns exported defs only", () => {
     const index = buildIndex([
       fn("boot", "src/boot.ts", ["run"], true),
@@ -112,7 +84,7 @@ describe("file entrypoint matching", () => {
   });
 });
 
-describe("inferEntries with file paths", () => {
+describe("resolveExplicitDiffEntries with --file", () => {
   test("expands a file path to exported keys", () => {
     const before = buildIndex([
       fn("boot", "src/boot.ts", ["old"], true),
@@ -123,12 +95,16 @@ describe("inferEntries with file paths", () => {
       fn("helper", "src/boot.ts", [], false),
     ]);
 
-    expect(inferEntries(before, after, ["src/boot.ts"], 12)).toEqual(["boot"]);
+    expect(
+      resolveExplicitDiffEntries(before, after, [], ["src/boot.ts"]).map(
+        (e) => e.key,
+      ),
+    ).toEqual(["boot"]);
   });
 });
 
-describe("CLI file entrypoints", () => {
-  test("tree -e <file> expands exported symbols in that file", () => {
+describe("CLI --file entrypoints", () => {
+  test("tree --file expands exported symbols in that file", () => {
     const host = workspace({
       "/packages/api/src/boot.ts": src`
         export function boot() {
@@ -148,7 +124,7 @@ describe("CLI file entrypoints", () => {
       `,
     });
 
-    const result = host.run("calldiff tree -e packages/api/src/boot.ts");
+    const result = host.run("calldiff tree --file packages/api/src/boot.ts");
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("boot()");
     expect(result.stdout).toContain("run()");
@@ -157,7 +133,7 @@ describe("CLI file entrypoints", () => {
     expect(result.stdout).not.toContain("decoy()");
   });
 
-  test("tree -e pins to the file when the same name exists elsewhere", () => {
+  test("tree -F pins to the file when the same name exists elsewhere", () => {
     const host = workspace({
       "/packages/a/src/flow.ts": src`
         export function start() {
@@ -173,13 +149,32 @@ describe("CLI file entrypoints", () => {
       `,
     });
 
-    const result = host.run("calldiff tree -e packages/b/src/flow.ts");
+    const result = host.run("calldiff tree -F packages/b/src/flow.ts");
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("fromB()");
     expect(result.stdout).not.toContain("fromA()");
   });
 
-  test("reach -e <file> walks exports in that file only", () => {
+  test("tree -e stays symbol-only even for path-shaped strings", () => {
+    const host = workspace({
+      "/src/boot.ts": src`
+        export function boot() {
+          run();
+        }
+        function run() {}
+      `,
+    });
+
+    const asFile = host.run("calldiff tree -e src/boot.ts");
+    expect(asFile.code).not.toBe(0);
+    expect(`${asFile.stdout}\n${asFile.stderr}`).toMatch(/Entrypoint not found/);
+
+    const asSymbol = host.run("calldiff tree -e boot");
+    expect(asSymbol.code).toBe(0);
+    expect(asSymbol.stdout).toContain("boot()");
+  });
+
+  test("reach --file walks exports in that file only", () => {
     const host = workspace({
       "/packages/a/src/flow.ts": src`
         export function start() {
@@ -198,14 +193,14 @@ describe("CLI file entrypoints", () => {
     });
 
     const result = host.run(
-      "calldiff reach -e packages/a/src/flow.ts --to notify",
+      "calldiff reach --file packages/a/src/flow.ts --to notify",
     );
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("notify()");
     expect(result.stdout).not.toContain("other()");
   });
 
-  test("diff -e <file> diffs exports defined in that file", () => {
+  test("diff --file diffs exports defined in that file", () => {
     const host = workspace();
     const before = host.commit("before", {
       "/src/boot.ts": src`
@@ -224,7 +219,7 @@ describe("CLI file entrypoints", () => {
       `,
     });
 
-    const result = host.run(`calldiff diff ${before} HEAD -e src/boot.ts`);
+    const result = host.run(`calldiff diff ${before} HEAD --file src/boot.ts`);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("boot()");
     expect(result.stdout).toContain("oldPath()");
@@ -243,7 +238,7 @@ describe("CLI file entrypoints", () => {
       `,
     });
 
-    const result = host.run("calldiff tree -e boot.ts");
+    const result = host.run("calldiff tree --file boot.ts");
     expect(result.code).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(
       /Ambiguous entrypoint file/,
@@ -260,7 +255,7 @@ describe("CLI file entrypoints", () => {
       `,
     });
 
-    const result = host.run("calldiff tree -e src/internal.ts");
+    const result = host.run("calldiff tree --file src/internal.ts");
     expect(result.code).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(
       /No exported entrypoints/,

--- a/test/file-entry.test.ts
+++ b/test/file-entry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { outdent } from "outdent";
 import {
-  isFileEntrypoint,
+  classifyEntrypoint,
   matchEntrypointFiles,
   resolveFileEntrypoints,
 } from "../src/calltree.js";
@@ -29,18 +29,37 @@ function fn(
   };
 }
 
-describe("file entrypoint detection", () => {
-  test("treats paths and source extensions as files", () => {
-    expect(isFileEntrypoint("src/routes.ts")).toBe(true);
-    expect(isFileEntrypoint("./packages/api/src/boot.ts")).toBe(true);
-    expect(isFileEntrypoint("routes.ts")).toBe(true);
-    expect(isFileEntrypoint("app.py")).toBe(true);
+describe("entrypoint classification", () => {
+  test("classifies by indexed file lookup, not string shape", () => {
+    const index = buildIndex([
+      fn("boot", "src/boot.ts", ["run"], true),
+      fn("run", "src/boot.ts", [], false),
+    ]);
+
+    expect(classifyEntrypoint("src/boot.ts", index)).toEqual({
+      kind: "file",
+      file: "src/boot.ts",
+    });
+    expect(classifyEntrypoint("boot.ts", index)).toEqual({
+      kind: "file",
+      file: "src/boot.ts",
+    });
+    expect(classifyEntrypoint("boot", index)).toEqual({
+      kind: "symbol",
+      key: "boot",
+    });
   });
 
-  test("leaves symbol names alone", () => {
-    expect(isFileEntrypoint("createAgentSession")).toBe(false);
-    expect(isFileEntrypoint("PiService.createAgentSession")).toBe(false);
-    expect(isFileEntrypoint("new Foo")).toBe(false);
+  test("path-shaped strings that are not indexed stay symbols / not-found", () => {
+    const index = buildIndex([fn("boot", "src/boot.ts", [], true)]);
+
+    expect(classifyEntrypoint("boot", index).kind).toBe("symbol");
+    expect(() => classifyEntrypoint("src/missing.ts", index)).toThrow(
+      /Entrypoint not found/,
+    );
+    expect(() => classifyEntrypoint("packages/api/src/routes.ts", index)).toThrow(
+      /Entrypoint not found/,
+    );
   });
 });
 

--- a/test/file-entry.test.ts
+++ b/test/file-entry.test.ts
@@ -126,11 +126,15 @@ describe("CLI --file entrypoints", () => {
 
     const result = host.run("calldiff tree --file packages/api/src/boot.ts");
     expect(result.code).toBe(0);
-    expect(result.stdout).toContain("boot()");
-    expect(result.stdout).toContain("run()");
-    expect(result.stdout).toContain("ready()");
-    expect(result.stdout).toContain("ping()");
-    expect(result.stdout).not.toContain("decoy()");
+    expect(result.stdout).toEqual(src`
+      calldiff tree working tree
+
+      boot()
+      └─ run()
+
+      ready()
+      └─ ping()
+    `);
   });
 
   test("tree -F pins to the file when the same name exists elsewhere", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an explicit **`--file` / `-F`** flag for file entrypoints. `--entry` / `-e` stays **symbols only** — no path/symbol guessing.

```bash
calldiff tree -e boot
calldiff tree --file packages/api/src/boot.ts
calldiff tree -F src/routes.ts
calldiff diff main HEAD --file src/routes.ts
calldiff reach --file packages/a/src/flow.ts --to notify
```

## Behavior

- `-e` / `--entry`: functionName or ClassName.method
- `--file` / `-F`: indexed source path → every **exported** symbol in that file
- File matching: exact path, or unique suffix (`boot.ts` → `packages/api/src/boot.ts`)
- Ambiguous suffixes / files with no exports error clearly
- Expansion is file-pinned so duplicate names in other packages don’t steal the tree
- `tree` / `reach` require `-e` or `--file` (or both)

## Tests

- Unit coverage for file matching / `--file` diff expansion
- CLI tests for `tree` / `reach` / `diff`, pinning, ambiguity, empty exports
- Confirms path-shaped `-e` values are rejected as missing symbols

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d09f3ca-55fb-47ad-8f44-df40c842d7c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d09f3ca-55fb-47ad-8f44-df40c842d7c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

