### PR TITLE
fix: resolve calls against the caller's own file, index local helpers (#19)

### DIFF
--- a/src/calltree.ts
+++ b/src/calltree.ts
@@ -1,4 +1,9 @@
-import { allFunctions, type FunctionIndex } from "./extract.js";
+import {
+  allFunctions,
+  definitionsInFile,
+  fileScopedKey,
+  type FunctionIndex,
+} from "./extract.js";
 import { pickLoc } from "./loc.js";
 import type { CallNode, CallStep, FunctionInfo } from "./types.js";
 
@@ -74,6 +79,48 @@ export function resolveFileEntrypoints(
   return exportsInFile(file, index);
 }
 
+/** Is `fn` declared inside `owner`'s source span? */
+function declaredInside(fn: FunctionInfo, owner?: FunctionInfo): boolean {
+  if (!owner || fn.line == null || owner.line == null) return false;
+  return (
+    fn.line >= owner.line &&
+    (fn.endLine ?? fn.line) <= (owner.endLine ?? owner.line)
+  );
+}
+
+/**
+ * Resolve one call to a definition.
+ *
+ * A definition in the file the call was written in always wins: the bare-key
+ * map is global and first-wins, so without this a call resolves to whichever
+ * same-named function happened to be indexed first, grafting an unrelated body
+ * into the tree. See #19.
+ *
+ * Falls back to the global map, which is what callers across file boundaries
+ * (the common case) rely on.
+ */
+function resolveCall(
+  key: string,
+  index: FunctionIndex,
+  callSite?: { file?: string; line?: number },
+  owner?: FunctionInfo,
+): FunctionInfo | undefined {
+  const file = callSite?.file ?? owner?.file;
+  if (file) {
+    const candidates = definitionsInFile(index, file, key);
+    if (candidates.length === 1) return candidates[0];
+    if (candidates.length > 1) {
+      // One file declaring the name twice: a helper declared inside the calling
+      // function shadows that file's top-level definition.
+      const shadowing = candidates.find(
+        (fn) => fn.local && declaredInside(fn, owner),
+      );
+      return shadowing ?? candidates[0];
+    }
+  }
+  return index.get(key);
+}
+
 function displayCallLabel(
   key: string,
   index: FunctionIndex,
@@ -91,6 +138,8 @@ function expandSteps(
   depth: number,
   maxDepth: number,
   visiting: Set<string>,
+  /** Definition these steps were read from, used to scope call resolution. */
+  owner?: FunctionInfo,
 ): CallNode[] {
   return steps.map((step) => {
     if (step.type === "branch") {
@@ -105,6 +154,7 @@ function expandSteps(
           depth,
           maxDepth,
           visiting,
+          owner,
         ),
       };
     }
@@ -116,6 +166,8 @@ function expandSteps(
       visiting,
       step.children,
       step,
+      undefined,
+      owner,
     );
   });
 }
@@ -130,9 +182,15 @@ function expandCall(
   callSite?: { file?: string; line?: number; endLine?: number },
   /** When set, expand this body even if another definition owns the bare key. */
   infoOverride?: FunctionInfo,
+  /** Definition this call was read from, used to scope call resolution. */
+  owner?: FunctionInfo,
 ): CallNode {
-  const info = infoOverride ?? index.get(key);
+  const info = infoOverride ?? resolveCall(key, index, callSite, owner);
   const label = displayCallLabel(key, index, info);
+
+  // Recursion is per definition, not per name: two same-named functions in
+  // different files calling each other is not a cycle.
+  const token = info ? fileScopedKey(info.file, info.key) : key;
 
   // Root uses the definition start line; every other node uses the call-site in the parent.
   const loc =
@@ -148,10 +206,10 @@ function expandCall(
     return { key, label, kind: "call", ...loc, children: [] };
   }
 
-  if (info && visiting.has(key)) {
+  if (info && visiting.has(token)) {
     // Still expand call-site JSX children; they are not a re-entry into `key`'s body.
     const callSiteChildren = inlineChildren?.length
-      ? expandSteps(inlineChildren, index, depth + 1, maxDepth, visiting)
+      ? expandSteps(inlineChildren, index, depth + 1, maxDepth, visiting, owner)
       : [];
     return {
       key,
@@ -162,14 +220,14 @@ function expandCall(
     };
   }
 
-  if (info) visiting.add(key);
+  if (info) visiting.add(token);
   const bodyChildren = info
-    ? expandSteps(info.steps, index, depth + 1, maxDepth, visiting)
+    ? expandSteps(info.steps, index, depth + 1, maxDepth, visiting, info)
     : [];
   const callSiteChildren = inlineChildren?.length
-    ? expandSteps(inlineChildren, index, depth + 1, maxDepth, visiting)
+    ? expandSteps(inlineChildren, index, depth + 1, maxDepth, visiting, owner)
     : [];
-  if (info) visiting.delete(key);
+  if (info) visiting.delete(token);
 
   return {
     key,

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -79,6 +79,17 @@ export type FunctionIndex = Map<string, FunctionInfo>;
  */
 const indexDefinitions = new WeakMap<FunctionIndex, FunctionInfo[]>();
 
+/**
+ * Definitions grouped by `file\0key`, so a call can be resolved against the
+ * file it was written in instead of the global bare-key map. See #19.
+ */
+const indexByFile = new WeakMap<FunctionIndex, Map<string, FunctionInfo[]>>();
+
+/** NUL cannot occur in a path or a symbol key, so it is a safe separator. */
+export function fileScopedKey(file: string, key: string): string {
+  return `${file}\0${key}`;
+}
+
 export function flattenCallKeys(steps: CallStep[]): string[] {
   const keys: string[] = [];
   const walk = (list: CallStep[]) => {
@@ -103,20 +114,58 @@ export function allFunctions(index: FunctionIndex): FunctionInfo[] {
   return indexDefinitions.get(index) ?? [...index.values()];
 }
 
+/**
+ * Definitions of `key` declared in `file`, top-level before locals, then in
+ * source order. Empty when that file declares none.
+ *
+ * Indexes created as plain Maps (not via {@link buildIndex}) fall back to a
+ * scan of their values.
+ */
+export function definitionsInFile(
+  index: FunctionIndex,
+  file: string,
+  key: string,
+): FunctionInfo[] {
+  const byFile = indexByFile.get(index);
+  if (byFile) return byFile.get(fileScopedKey(file, key)) ?? [];
+  return [...index.values()].filter(
+    (fn) => fn.file === file && fn.key === key,
+  );
+}
+
 export function buildIndex(functions: FunctionInfo[]): FunctionIndex {
   const index: FunctionIndex = new Map();
-  for (const fn of functions) {
+  const byFile = new Map<string, FunctionInfo[]>();
+
+  const record = (fn: FunctionInfo) => {
+    const scoped = fileScopedKey(fn.file, fn.key);
+    const existing = byFile.get(scoped);
+    if (existing) existing.push(fn);
+    else byFile.set(scoped, [fn]);
+
     if (!index.has(fn.key)) {
       index.set(fn.key, fn);
     }
     if (fn.key.endsWith(".constructor")) {
       const className = fn.key.slice(0, -".constructor".length);
       const newKey = `new ${className}`;
+      const ctor = { ...fn, key: newKey, label: `new ${className}()` };
+      const scopedNew = fileScopedKey(fn.file, newKey);
+      const existingNew = byFile.get(scopedNew);
+      if (existingNew) existingNew.push(ctor);
+      else byFile.set(scopedNew, [ctor]);
       if (!index.has(newKey)) {
-        index.set(newKey, { ...fn, key: newKey, label: `new ${className}()` });
+        index.set(newKey, ctor);
       }
     }
-  }
+  };
+
+  // Top level first: a helper declared inside a body must never take a bare key
+  // away from a real top-level definition somewhere else in the repo (#19).
+  for (const fn of functions) if (!fn.local) record(fn);
+  for (const fn of functions) if (fn.local) record(fn);
+
   indexDefinitions.set(index, functions.slice());
+  indexByFile.set(index, byFile);
   return index;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ export {
   resolveFileEntrypoints,
 } from "./calltree.js";
 export { diffTrees, treeHasChanges } from "./diff.js";
-export { allFunctions, buildIndex, extractFunctions } from "./extract.js";
+export {
+  allFunctions,
+  buildIndex,
+  definitionsInFile,
+  extractFunctions,
+} from "./extract.js";
 export { formatSourceLoc, pickLoc } from "./loc.js";
 export { collectPathsTo, findReachPaths, pathToTree } from "./reach.js";
 export { renderDiff, renderTree } from "./render.js";

--- a/src/languages/javascript.ts
+++ b/src/languages/javascript.ts
@@ -481,6 +481,80 @@ function bodyOf(node: SyntaxNode): SyntaxNode | null {
   );
 }
 
+/**
+ * Register definitions declared inside a function body.
+ *
+ * `visitStatement` only walks top-level statements, so a helper declared inside
+ * a body was never indexed at all, and calls to it fell through to whatever
+ * top-level function elsewhere in the repo happened to share the bare name.
+ * See #19.
+ *
+ * Helper bodies are still not attributed to the outer caller (contract #5);
+ * they become definitions in their own right, marked `local`.
+ */
+function collectLocalDefinitions(
+  file: string,
+  body: SyntaxNode | null,
+  className: string | null,
+  functions: FunctionInfo[],
+) {
+  if (!body) return;
+
+  const walk = (node: SyntaxNode): void => {
+    for (const child of namedChildren(node)) {
+      if (
+        child.type === "function_declaration" ||
+        child.type === "generator_function_declaration"
+      ) {
+        const id = childByType(child, "identifier");
+        handleFunctionNode(
+          file,
+          child,
+          id?.text ?? null,
+          false,
+          className,
+          functions,
+          true,
+        );
+        continue;
+      }
+
+      if (
+        child.type === "lexical_declaration" ||
+        child.type === "variable_declaration"
+      ) {
+        for (const d of namedChildren(child)) {
+          if (d.type !== "variable_declarator") continue;
+          const id = childByType(d, "identifier");
+          const init =
+            childByType(d, "arrow_function") ??
+            childByType(d, "function_expression");
+          if (id && init) {
+            handleFunctionNode(
+              file,
+              init,
+              id.text,
+              false,
+              className,
+              functions,
+              true,
+            );
+          }
+        }
+        // Fall through: `walk` skips the initializer bodies as fn-like below,
+        // so a declaration list is never registered twice.
+      }
+
+      // Anonymous callbacks are not addressable by name; skip their bodies.
+      if (isFnLike(child.type)) continue;
+
+      walk(child);
+    }
+  };
+
+  walk(body);
+}
+
 function handleFunctionNode(
   file: string,
   node: SyntaxNode,
@@ -488,22 +562,25 @@ function handleFunctionNode(
   exported: boolean,
   className: string | null,
   functions: FunctionInfo[],
+  /** Declared inside another body: key stays bare and resolution is file-scoped. */
+  local = false,
 ) {
   if (!name) return;
-  const key = className ? `${className}.${name}` : name;
-  functions.push(
-    functionFromParts(
-      file,
-      key,
-      key,
-      paramsOf(node),
-      bodyOf(node),
-      exported,
-      node.startIndex,
-      node.endIndex,
-      className,
-    ),
+  const key = className && !local ? `${className}.${name}` : name;
+  const body = bodyOf(node);
+  const info = functionFromParts(
+    file,
+    key,
+    key,
+    paramsOf(node),
+    body,
+    exported,
+    node.startIndex,
+    node.endIndex,
+    className,
   );
+  functions.push(local ? { ...info, local: true } : info);
+  collectLocalDefinitions(file, body, className, functions);
 }
 
 function handleClass(
@@ -551,6 +628,7 @@ function handleClass(
           className,
         ),
       );
+      collectLocalDefinitions(file, fnBody, className, functions);
     }
 
     if (element.type === "field_definition") {

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -345,6 +345,80 @@ function functionFromParts(
   };
 }
 
+/**
+ * Register definitions declared inside a function body.
+ *
+ * `visitStatement` only walks top-level statements, so a helper declared inside
+ * a body was never indexed at all, and calls to it fell through to whatever
+ * top-level function elsewhere in the repo happened to share the bare name.
+ * See #19.
+ *
+ * Helper bodies are still not attributed to the outer caller (contract #5);
+ * they become definitions in their own right, marked `local`.
+ */
+function collectLocalDefinitions(
+  file: string,
+  body: SyntaxNode | null,
+  className: string | null,
+  functions: FunctionInfo[],
+) {
+  if (!body) return;
+
+  const walk = (node: SyntaxNode): void => {
+    for (const child of namedChildren(node)) {
+      if (
+        child.type === "function_declaration" ||
+        child.type === "generator_function_declaration"
+      ) {
+        const id = childByType(child, "identifier");
+        handleFunctionNode(
+          file,
+          child,
+          id?.text ?? null,
+          false,
+          className,
+          functions,
+          true,
+        );
+        continue;
+      }
+
+      if (
+        child.type === "lexical_declaration" ||
+        child.type === "variable_declaration"
+      ) {
+        for (const d of namedChildren(child)) {
+          if (d.type !== "variable_declarator") continue;
+          const id = childByType(d, "identifier");
+          const init =
+            childByType(d, "arrow_function") ??
+            childByType(d, "function_expression");
+          if (id && init) {
+            handleFunctionNode(
+              file,
+              init,
+              id.text,
+              false,
+              className,
+              functions,
+              true,
+            );
+          }
+        }
+        // Fall through: `walk` skips the initializer bodies as fn-like below,
+        // so a declaration list is never registered twice.
+      }
+
+      // Anonymous callbacks are not addressable by name; skip their bodies.
+      if (isFnLike(child.type)) continue;
+
+      walk(child);
+    }
+  };
+
+  walk(body);
+}
+
 function handleFunctionNode(
   file: string,
   node: SyntaxNode,
@@ -352,9 +426,11 @@ function handleFunctionNode(
   exported: boolean,
   className: string | null,
   functions: FunctionInfo[],
+  /** Declared inside another body: key stays bare and resolution is file-scoped. */
+  local = false,
 ) {
   if (!name) return;
-  const key = className ? `${className}.${name}` : name;
+  const key = className && !local ? `${className}.${name}` : name;
   const params = childByType(node, "formal_parameters");
   const body =
     childByType(node, "statement_block") ??
@@ -370,19 +446,19 @@ function handleFunctionNode(
     ) ??
     null;
 
-  functions.push(
-    functionFromParts(
-      file,
-      key,
-      key,
-      params,
-      body,
-      exported,
-      node.startIndex,
-      node.endIndex,
-      className,
-    ),
+  const info = functionFromParts(
+    file,
+    key,
+    key,
+    params,
+    body,
+    exported,
+    node.startIndex,
+    node.endIndex,
+    className,
   );
+  functions.push(local ? { ...info, local: true } : info);
+  collectLocalDefinitions(file, body, className, functions);
 }
 
 function handleClass(
@@ -432,6 +508,7 @@ function handleClass(
           className,
         ),
       );
+      collectLocalDefinitions(file, fnBody, className, functions);
     }
 
     if (element.type === "public_field_definition") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,12 @@ export interface FunctionInfo {
   /** Ordered body steps (calls + if/else branches) */
   steps: CallStep[];
   exported: boolean;
+  /**
+   * Declared inside another function body (a helper or closure) rather than at
+   * file top level. Locals only answer calls made from their own file, so a
+   * helper never shadows a top-level definition elsewhere in the repo.
+   */
+  local?: boolean;
   /** Source span for change detection */
   start: number;
   end: number;

--- a/test/local-definitions.test.ts
+++ b/test/local-definitions.test.ts
@@ -1,0 +1,162 @@
+import { outdent } from "outdent";
+import { describe, expect, test } from "vitest";
+import { buildIndex, extractFunctions } from "../src/extract.js";
+import { workspace } from "./workspace.js";
+
+/** Keep the trailing newline so expectations match CLI stdout. */
+const src = outdent({ trimTrailingNewline: false });
+
+/**
+ * Helpers declared inside a function body.
+ *
+ * They were never extracted, so a call to one resolved through the global
+ * bare-key map to whatever top-level function elsewhere in the repo shared the
+ * name — grafting an unrelated body into the tree. See #19.
+ */
+describe("locally declared helpers", () => {
+  const tree = src`
+    export function buildTree(rows: Row[]): Tree {
+      const byId = index(rows);
+      const walk = (id: string, depth: number): void => {
+        for (const kid of byId[id].children) walk(kid, depth + 1);
+      };
+      for (const r of roots) walk(r, 0);
+      return byId;
+    }
+
+    function index(rows: Row[]) {
+      return rows;
+    }
+  `;
+
+  const gate = src`
+    import { readdirSync } from "node:fs";
+
+    export function walk(dir: string, rel = ""): void {
+      readdirSync(dir);
+    }
+  `;
+
+  test("expands the caller's own helper, not a same-named function elsewhere", () => {
+    const host = workspace({
+      "/scripts/gate.ts": gate,
+      "/src/tree.ts": tree,
+    });
+
+    const result = host.run("calldiff tree --entry buildTree");
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(outdent`
+      buildTree(rows)
+      ├─ index(rows)
+      └─ walk(id, depth)
+         └─ walk(id, depth) ⇄
+    `);
+    expect(result.stdout).not.toContain("readdirSync");
+  });
+
+  test("does not depend on which file is indexed first", () => {
+    // `scripts/` sorts before `src/`; `zz/` sorts after.
+    const gateFirst = workspace({
+      "/scripts/gate.ts": gate,
+      "/src/tree.ts": tree,
+    });
+    const treeFirst = workspace({
+      "/src/tree.ts": tree,
+      "/zz/gate.ts": gate,
+    });
+
+    const a = gateFirst.run("calldiff tree --entry buildTree");
+    const b = treeFirst.run("calldiff tree --entry buildTree");
+
+    expect(a.code).toBe(0);
+    expect(b.code).toBe(0);
+    expect(a.stdout).toBe(b.stdout);
+  });
+
+  test("the top-level definition still expands when entered directly", () => {
+    const host = workspace({
+      "/scripts/gate.ts": gate,
+      "/src/tree.ts": tree,
+    });
+
+    const result = host.run("calldiff tree --entry walk");
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(outdent`
+      walk(dir, rel)
+      └─ readdirSync()
+    `);
+  });
+
+  test("reach does not report a path through a grafted body", () => {
+    const host = workspace({
+      "/src/tree.ts": tree,
+      "/scripts/gate.ts": src`
+        import { sendEmail } from "../src/mail";
+
+        export function walk(dir: string): void {
+          sendEmail(dir);
+        }
+      `,
+      "/src/mail.ts": src`
+        export function sendEmail(id: string): void {
+          console.log(id);
+        }
+      `,
+    });
+
+    // buildTree imports nothing from mail.ts; the only route to sendEmail was
+    // through the impostor `walk` in scripts/gate.ts.
+    const result = host.run("calldiff reach -e buildTree --to sendEmail");
+
+    expect(result.stdout).toContain("No paths from buildTree to sendEmail.");
+  });
+
+  test("a helper is extracted as its own definition, marked local", () => {
+    const fns = extractFunctions("src/tree.ts", tree);
+
+    expect(fns.map((fn) => fn.key)).toContain("walk");
+    expect(fns.find((fn) => fn.key === "walk")?.local).toBe(true);
+    expect(fns.find((fn) => fn.key === "buildTree")?.local).toBeUndefined();
+  });
+
+  test("a helper never takes the bare key from a top-level definition", () => {
+    const index = buildIndex([
+      ...extractFunctions("src/tree.ts", tree),
+      ...extractFunctions("scripts/gate.ts", gate),
+    ]);
+
+    // `src/tree.ts` is indexed first, but its local helper must not become the
+    // global answer for `walk`.
+    expect(index.get("walk")?.file).toBe("scripts/gate.ts");
+  });
+
+  test("javascript helpers resolve the same way", () => {
+    const host = workspace({
+      "/scripts/gate.js": src`
+        export function walk(dir) {
+          readdirSync(dir);
+        }
+      `,
+      "/src/tree.js": src`
+        export function buildTree(rows) {
+          const walk = (id) => visit(id);
+          walk(rows);
+        }
+
+        function visit(id) {}
+      `,
+    });
+
+    const result = host.run("calldiff tree --entry buildTree");
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(outdent`
+      buildTree(rows)
+      └─ walk(id)
+         └─ visit(id)
+    `);
+    expect(result.stdout).not.toContain("readdirSync");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #19: a call now resolves to a definition in the file it was written in, and helpers declared inside a function body are indexed instead of ignored. Together those stop `calldiff` from splicing an unrelated function body into a call tree when two files share a bare name.

Follows the shape of #22 — the two bugs are the same root cause seen from opposite ends. #20 was a path silently *deleted*; this one is a path silently *invented*.

## The bug

Two files, no import between them ([full repro in #19](https://github.com/tanishqkancharla/calldiff/issues/19)):

```console
$ calldiff tree --entry buildTree      # before
buildTree(rows)
├─ index(rows)
└─ walk(dir, rel)
   ├─ readdirSync()
   ├─ if (SKIP_DIRS.has(name))
   ...
```

`buildTree` is reported as doing filesystem I/O. It does not. The whole `walk` subtree is `scripts/gate.ts`, spliced into `src/tree.ts`, and the arity is wrong too — the real helper is `walk(id, depth)`.

`--json` already contains the contradiction: the `walk` node carries `"file": "src/tree.ts"` while every one of its children carries `"file": "scripts/gate.ts"`. Nothing surfaces it, and agents consuming the JSON have no way to tell a grafted subtree from a real one.

**reach fabricates paths through the same graft.** With the impostor `walk` calling a repo-local `sendEmail`:

```console
$ calldiff reach -e buildTree --to sendEmail      # before
buildTree(rows)
└─ walk(dir, rel)
   └─ sendEmail(id)
```

There is no import path between them. #22's fix cannot catch this: `allFunctions()` also only ever saw one `walk`, because the nested definition never entered extraction, so `resolveAllEntries` has no second candidate to find.

## Approach

Two independent causes had to line up, and neither alone is visible — so both halves are fixed.

1. **`extractFromTree` walked only top-level statements**, so a helper declared inside a body was never extracted. `collectLocalDefinitions` now registers them as definitions in their own right, marked `local`. Bodies are still not attributed to the outer caller (contract #5). TS/TSX and JS/JSX; other extractors are untouched and unaffected.

2. **`index.get(key)` was a global first-wins lookup** with no reference to the call site. `buildIndex` now keeps a `file\0key` side table and `resolveCall` consults the calling file first, falling back to the global map for cross-file calls.

`local` is what keeps this from trading one shadowing bug for another: a helper must never take a bare key from a real top-level definition elsewhere, so `buildIndex` records every top-level function before any local one.

The side table is a WeakMap beside the index rather than extra entries inside it (same shape as `indexDefinitions` from #22), so `FunctionIndex` is unchanged and `resolveEntry` still sees only real symbol keys.

Entry resolution is untouched — `buildCallTree` has no call site, so `calldiff tree --entry walk` picks its entrypoint exactly as before.

One incidental fix: the recursion guard is now keyed by `file\0key` instead of the bare name. Two same-named functions in different files were previously indistinguishable so it could not come up; now that they can be told apart, mutual calls between them would otherwise be reported as recursion (`⇄`) and left unexpanded.

## Result

```console
$ calldiff tree --entry buildTree      # after
buildTree(rows)
├─ index(rows)
└─ walk(id, depth)
   └─ walk(id, depth) ⇄

$ calldiff reach -e buildTree --to sendEmail
No paths from buildTree to sendEmail.
```

Entering `scripts/gate.ts` directly still expands `walk(dir, rel)` correctly.

## Test plan

New `test/local-definitions.test.ts`, using the `workspace()` host from #22 (the bug needs more than one file):

- [x] The caller's own helper expands; no `readdirSync` from the other file
- [x] Output does not change when files are reordered (`scripts/` vs `zz/`)
- [x] The top-level definition still expands when entered directly
- [x] reach reports no path through the grafted body
- [x] Unit: the helper is extracted and marked `local`
- [x] Unit: a local helper does not take the bare key from a top-level definition
- [x] JavaScript parity

Full suite green (222 passing) and `tsc --noEmit` clean.

Note for reproducing locally: `test/swift.test.ts` can time out on a cold grammar cache — `@tree-sitter-grammars/tree-sitter-swift` takes ~30s to install against the default 5s test timeout, and each `npm install --prefix` into the cache prunes previously installed grammars. It is unrelated to this change and passes with `--testTimeout=120000` or on a warm cache.
