### PR TITLE
feat(typescript): extract functions passed to wrapper calls

### DIFF
--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -345,6 +345,143 @@ function functionFromParts(
   };
 }
 
+const TRANSPARENT_EXPRESSIONS = new Set([
+  "parenthesized_expression",
+  "as_expression",
+  "satisfies_expression",
+  "non_null_expression",
+  "type_assertion",
+]);
+
+/**
+ * Peel the wrappers TypeScript allows around a value — `(fn)`, `fn as Handler`,
+ * `fn satisfies Handler`, `<Handler>fn`, `fn!` — so the node underneath can be
+ * matched on its own terms. In every one of these the value is the first named
+ * child, except `<T>fn`, where the leading `type_arguments` comes first.
+ */
+function stripTypeWrappers(node: SyntaxNode): SyntaxNode {
+  let current = node;
+  while (TRANSPARENT_EXPRESSIONS.has(current.type)) {
+    const inner = namedChildren(current).find(
+      (c) => c.type !== "type_arguments",
+    );
+    if (!inner) return current;
+    current = inner;
+  }
+  return current;
+}
+
+/**
+ * `export default defineEventHandler(async (event) => {...})` — the module's
+ * payload is a function argument to a wrapper call, not a declaration. Extract
+ * it, keyed by its own name where it has one and by `fallbackName` otherwise:
+ * the declared variable for `const handler = wrapper(...)`, the file stem for a
+ * default export, so routes in different files do not collide.
+ *
+ * Returns whether a function was found, so a nested call that holds none —
+ * `createHandler(makeOptions(), async () => {...})` — does not stop the scan
+ * before the sibling argument that does.
+ */
+function unwrapWrappedFunction(
+  file: string,
+  call: SyntaxNode,
+  fallbackName: string | null,
+  exported: boolean,
+  functions: FunctionInfo[],
+  className: string | null = null,
+  local = false,
+): boolean {
+  const args = namedChildren(call).find((c) => c.type === "arguments");
+  if (!args) return false;
+  for (const rawArg of namedChildren(args)) {
+    const arg = stripTypeWrappers(rawArg);
+    // Wrappers compose: `memo(forwardRef(function Input() {...}))`.
+    if (arg.type === "call_expression") {
+      if (
+        unwrapWrappedFunction(
+          file,
+          arg,
+          fallbackName,
+          exported,
+          functions,
+          className,
+          local,
+        )
+      ) {
+        return true;
+      }
+      continue;
+    }
+    // Generators count too: `Effect.gen(function* () {...})` is this shape.
+    if (arg.type === "method_definition" || !isFnLike(arg.type)) continue;
+    const named = childByType(arg, "identifier");
+    handleFunctionNode(
+      file,
+      arg,
+      named?.text ?? fallbackName,
+      exported,
+      className,
+      functions,
+      local,
+    );
+    return true;
+  }
+  return false;
+}
+
+/** File path minus extension — the key for an anonymous default export. */
+function fileStem(file: string): string {
+  return file.replace(/\.[^./]+$/, "");
+}
+
+/**
+ * Extract a function from a variable declarator's initialiser: a direct
+ * arrow/function expression, or a function argument to a wrapper call.
+ */
+function extractDeclaratorFunction(
+  file: string,
+  d: SyntaxNode,
+  exported: boolean,
+  functions: FunctionInfo[],
+  className: string | null = null,
+  local = false,
+): void {
+  const id = childByType(d, "identifier");
+  if (!id) return;
+  // The initialiser is the declarator's value child — everything but the
+  // name and any type annotation — with its type wrappers peeled off.
+  const value = namedChildren(d).find(
+    (c) => c !== id && c.type !== "type_annotation",
+  );
+  const init = value ? stripTypeWrappers(value) : null;
+  if (!init) return;
+  if (init.type === "arrow_function" || init.type === "function_expression") {
+    handleFunctionNode(
+      file,
+      init,
+      id.text,
+      exported,
+      className,
+      functions,
+      local,
+    );
+    return;
+  }
+  // `const handler = defineEventHandler(async (event) => {...})` — the
+  // initialiser is the wrapper call, so the function is one level in.
+  if (init.type === "call_expression") {
+    unwrapWrappedFunction(
+      file,
+      init,
+      id.text,
+      exported,
+      functions,
+      className,
+      local,
+    );
+  }
+}
+
 /**
  * Register definitions declared inside a function body.
  *
@@ -389,21 +526,14 @@ function collectLocalDefinitions(
       ) {
         for (const d of namedChildren(child)) {
           if (d.type !== "variable_declarator") continue;
-          const id = childByType(d, "identifier");
-          const init =
-            childByType(d, "arrow_function") ??
-            childByType(d, "function_expression");
-          if (id && init) {
-            handleFunctionNode(
-              file,
-              init,
-              id.text,
-              false,
-              className,
-              functions,
-              true,
-            );
-          }
+          extractDeclaratorFunction(
+            file,
+            d,
+            false,
+            functions,
+            className,
+            true,
+          );
         }
         // Fall through: `walk` skips the initializer bodies as fn-like below,
         // so a declaration list is never registered twice.
@@ -537,9 +667,10 @@ function visitStatement(
   functions: FunctionInfo[],
 ) {
   if (node.type === "export_statement") {
-    const decl =
+    const found =
       namedChildren(node).find((c) => c.type !== "export_clause") ?? null;
-    if (!decl) return;
+    if (!found) return;
+    const decl = stripTypeWrappers(found);
 
     const isDefault = node.text.startsWith("export default");
 
@@ -571,6 +702,16 @@ function visitStatement(
       decl.type === "class"
     ) {
       handleClass(file, decl, true, functions);
+      return;
+    }
+    if (decl.type === "call_expression") {
+      unwrapWrappedFunction(
+        file,
+        decl,
+        isDefault ? fileStem(file) : null,
+        true,
+        functions,
+      );
       return;
     }
     if (
@@ -605,13 +746,7 @@ function visitStatement(
   ) {
     for (const d of namedChildren(node)) {
       if (d.type !== "variable_declarator") continue;
-      const id = childByType(d, "identifier");
-      const init =
-        childByType(d, "arrow_function") ??
-        childByType(d, "function_expression");
-      if (id && init) {
-        handleFunctionNode(file, init, id.text, exported, null, functions);
-      }
+      extractDeclaratorFunction(file, d, exported, functions);
     }
   }
 }

--- a/test/typescript-wrappers.test.ts
+++ b/test/typescript-wrappers.test.ts
@@ -1,0 +1,287 @@
+import { expect, test as vitestTest } from "vitest";
+import { buildIndex, extractFunctions } from "../src/extract.js";
+import { test } from "./expectCallstack.js";
+
+test("typescript: extracts a named function passed to a wrapper call", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      export default defineEventHandler(function handleCreate(event) {
+    -   validateBody(event);
+    +   const input = parseBody(event);
+        if (!input) {
+          throwBadRequest();
+        } else {
+          persist(input);
+        }
+      });
+
+    + function parseBody(event) {
+    +   readValidatedBody(event);
+    +   return input;
+    + }
+    `,
+    "handleCreate",
+    { file: "api/create.post.ts" },
+  ).toEqual(`
+      handleCreate(event)
+    - ├─ validateBody()
+    + ├─ parseBody(event)
+    + │  └─ readValidatedBody()
+      ├─ if (!input)
+         └─ throwBadRequest()
+      └─ else
+         └─ persist()
+  `);
+});
+
+vitestTest("anonymous wrapped default exports are keyed by file path", () => {
+  const source =
+    "export default defineEventHandler(async (event) => { requireUserSession(event) })";
+
+  const organization = extractFunctions(
+    "apps/app/server/api/organization/index.post.ts",
+    source,
+  );
+  const plans = extractFunctions(
+    "apps/admin/server/api/billing/plans/index.post.ts",
+    source,
+  );
+
+  expect(organization.map((fn) => fn.key)).toEqual([
+    "apps/app/server/api/organization/index.post",
+  ]);
+  expect(plans.map((fn) => fn.key)).toEqual([
+    "apps/admin/server/api/billing/plans/index.post",
+  ]);
+
+  // Keyed by stem alone these collide, and one handler shadows the other.
+  const index = buildIndex([...organization, ...plans]);
+  expect(index.size).toBe(2);
+});
+
+vitestTest("wrapper arguments keep their call steps", () => {
+  const [handler] = extractFunctions(
+    "apps/app/server/api/organization/index.post.ts",
+    `export default defineEventHandler(async (event) => {
+       requireUserSession(event)
+       readValidatedBody(event)
+       useDrizzle()
+     })`,
+  );
+
+  expect(handler?.steps.map((step) => step.type === "call" && step.key)).toEqual(
+    ["requireUserSession", "readValidatedBody", "useDrizzle"],
+  );
+});
+
+vitestTest("wrapper calls in variable declarators are unwrapped", () => {
+  const functions = extractFunctions(
+    "server/api/orders/index.post.ts",
+    `export const handler = defineEventHandler(async (event) => { charlie(event) })
+     const cached = defineCachedFunction(async () => { delta() })
+     export const named = defineEventHandler(function inner(event) { echo(event) })
+     const plain = (input) => { golf(input) }`,
+  );
+
+  // Anonymous callbacks take the declared variable name; a named function
+  // expression keeps its own, as it does for a default export.
+  expect(functions.map((fn) => [fn.key, fn.exported])).toEqual([
+    ["handler", true],
+    ["cached", false],
+    ["inner", true],
+    ["plain", false],
+  ]);
+
+  const [handler] = functions;
+  expect(handler?.steps.map((step) => step.type === "call" && step.key)).toEqual(
+    ["charlie"],
+  );
+});
+
+vitestTest("type wrappers around a callback are peeled off", () => {
+  const functions = extractFunctions(
+    "server/handlers.ts",
+    `export const satisfied = defineEventHandler(((event) => { a(event) }) satisfies EventHandler)
+     export const asserted = defineEventHandler(((event) => { b(event) }) as EventHandler)
+     export const parenthesized = defineEventHandler(((event) => { c(event) }))
+     export const angled = defineEventHandler(<EventHandler>((event) => { d(event) }))
+     export const generated = Effect.gen((function* () { e() }) satisfies Gen)`,
+  );
+
+  expect(functions.map((fn) => fn.key)).toEqual([
+    "satisfied",
+    "asserted",
+    "parenthesized",
+    "angled",
+    "generated",
+  ]);
+  expect(functions[0]?.steps.map((s) => s.type === "call" && s.key)).toEqual([
+    "a",
+  ]);
+});
+
+vitestTest("type wrappers around the wrapper call itself are peeled off", () => {
+  const functions = extractFunctions(
+    "server/api/orders/index.post.ts",
+    `export default (defineEventHandler((event) => { chargeCard(event) })) as EventHandler`,
+  );
+
+  expect(functions.map((fn) => [fn.key, fn.exported])).toEqual([
+    ["server/api/orders/index.post", true],
+  ]);
+});
+
+vitestTest("a call argument holding no function does not stop the scan", () => {
+  const functions = extractFunctions(
+    "server/handlers.ts",
+    `export const handler = createHandler(makeOptions(), async () => { chargeCard() })
+     export const effectful = Layer.effect(makeTag(), Effect.gen(function* () { init() }))`,
+  );
+
+  expect(functions.map((fn) => fn.key)).toEqual(["handler", "effectful"]);
+  expect(functions[0]?.steps.map((s) => s.type === "call" && s.key)).toEqual([
+    "chargeCard",
+  ]);
+});
+
+vitestTest("generator arguments to wrapper calls are unwrapped", () => {
+  const functions = extractFunctions(
+    "svc/user.ts",
+    `export const getUser = Effect.gen(function* () {
+       const cfg = yield* Config
+       return yield* findUser(cfg.id)
+     })
+     export const layer = Layer.effect(Tag, Effect.gen(function* () { init() }))`,
+  );
+
+  expect(functions.map((fn) => [fn.key, fn.exported])).toEqual([
+    ["getUser", true],
+    ["layer", true],
+  ]);
+  // `yield* Config` is a bare reference, so only the real calls are steps.
+  expect(functions[0]?.steps.map((s) => s.type === "call" && s.key)).toEqual([
+    "findUser",
+  ]);
+});
+
+test("tsx: diffs a component wrapped in React.memo", ({ expectCallstack }) => {
+  expectCallstack(
+    `
+      export default memo(function OrderRow({ order }) {
+        const total = formatCurrency(order.total);
+        if (order.isPending) {
+    -     return <Spinner />;
+    +     return <SkeletonRow />;
+        }
+    +   trackImpression(order.id);
+        return <Row total={total} />;
+      });
+    `,
+    "OrderRow",
+    { file: "OrderRow.tsx" },
+  ).toEqual(`
+      OrderRow({})
+      ├─ formatCurrency()
+      ├─ if (order.isPending)
+    -    ├─ Spinner()
+    +    └─ SkeletonRow()
+    + ├─ trackImpression()
+      └─ Row()
+  `);
+});
+
+vitestTest("tsx: composed wrappers are unwrapped to the inner function", () => {
+  const functions = extractFunctions(
+    "components/Input.tsx",
+    `export default memo(forwardRef(function Input(props, ref) { focusOnMount(ref) }))`,
+  );
+
+  expect(functions.map((fn) => [fn.key, fn.exported])).toEqual([
+    ["Input", true],
+  ]);
+  expect(functions[0]?.steps.map((s) => s.type === "call" && s.key)).toEqual([
+    "focusOnMount",
+  ]);
+});
+
+vitestTest("tsx: a wrapper over a bare reference adds nothing", () => {
+  // `memo(RowBase)` is an alias — RowBase is extracted at its own definition,
+  // so there is no second function to record here.
+  const functions = extractFunctions(
+    "components/Row.tsx",
+    `function RowBase({ item }) { renderCell(item) }
+     export const Row = memo(RowBase)`,
+  );
+
+  expect(functions.map((fn) => fn.key)).toEqual(["RowBase"]);
+});
+
+vitestTest("tsx: an anonymous memo callback keys off the declared name", () => {
+  const functions = extractFunctions(
+    "components/OrderBadge.tsx",
+    `export const OrderBadge = memo(({ status }) => {
+       return <Badge tone={toneFor(status)} />
+     })`,
+  );
+
+  expect(functions.map((fn) => fn.key)).toEqual(["OrderBadge"]);
+});
+
+vitestTest("an exported wrapped declarator is selectable as an entry", () => {
+  const index = buildIndex(
+    extractFunctions(
+      "server/api/orders/index.post.ts",
+      "export const handler = defineEventHandler(async (event) => { chargeCard() })",
+    ),
+  );
+
+  expect(index.get("handler")?.exported).toBe(true);
+});
+
+vitestTest("wrapped helpers inside a body are extracted as local", () => {
+  const functions = extractFunctions(
+    "src/boot.ts",
+    `export function boot() {
+       const handler = defineEventHandler(async (event) => { chargeCard(event) })
+       handler()
+     }`,
+  );
+
+  expect(
+    functions.map((fn) => [fn.key, fn.local ?? false, fn.exported]),
+  ).toEqual([
+    ["boot", false, true],
+    ["handler", true, false],
+  ]);
+  expect(
+    functions
+      .find((fn) => fn.key === "handler")
+      ?.steps.map((s) => s.type === "call" && s.key),
+  ).toEqual(["chargeCard"]);
+});
+
+test("typescript: a wrapped local helper expands from the caller", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      export function boot() {
+        const handler = defineEventHandler(async (event) => {
+    -     chargeCard(event);
+    +     refund(event);
+        });
+        handler();
+      }
+    `,
+    "boot",
+    { file: "boot.ts" },
+  ).toEqual(`
+      boot()
+      ├─ defineEventHandler()
+      └─ handler(event)
+    -    ├─ chargeCard()
+    +    └─ refund()
+  `);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #27. Rebases #30 onto current `main` after #29.

Wrapper calls hid the function argument, so handlers never entered the graph:

```
export default defineEventHandler(async (event) => …)   []  →  server/api/orders/index.post
export const getOrder = defineEventHandler(async …)     []  →  getOrder
export const OrderBadge = memo(({ status }) => …)       []  →  OrderBadge
export default memo(forwardRef(function Input(…) …))    []  →  Input
export const getUser = Effect.gen(function* () …)       []  →  getUser
```

Anonymous default exports are keyed by file path minus extension so two `index.post.ts` routes do not collide.

## Rebase onto #29

`collectLocalDefinitions` used the old “initializer must be an arrow or function expression” check. A nested `const handler = defineEventHandler(...)` stayed invisible. Both top-level declarators and local helpers now share `extractDeclaratorFunction`.

`yield*` of a bare identifier (`yield* Config`) is still not a call — same as `await fetchTransactionAmount`. Call expressions inside the generator are recorded.

## Tests

15 tests in `test/typescript-wrappers.test.ts`, including a local wrapped helper that expands from its caller. On `main` without the extractor change, 12 of the original 13 fail; with it, all pass. `tsc` is clean.

`.js` / `.jsx` still have the original hole (`javascript.ts` was not updated). That is a follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b3a5de5-6249-4cd5-946e-2e28ef27aa50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b3a5de5-6249-4cd5-946e-2e28ef27aa50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

