### PR TITLE
fix(kotlin): traverse lambda arguments as call-site children

### DIFF
--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -77,6 +77,19 @@ function statementsOf(body: SyntaxNode | null): SyntaxNode[] {
   return [body];
 }
 
+/**
+ * Body statements of a lambda/anonymous-function argument. Kotlin higher-order
+ * calls (`runBlocking { ... }`, `use { ... }`) execute these as part of the
+ * enclosing call flow, so they nest as call-site children of the receiving call.
+ */
+function lambdaBodyStatements(lambda: SyntaxNode): SyntaxNode[] {
+  if (lambda.type === "anonymous_function") {
+    return statementsOf(childByType(lambda, "function_body"));
+  }
+  const stmts = childByType(lambda, "statements");
+  return stmts ? namedChildren(stmts) : [];
+}
+
 function collectStatements(
   file: string,
   statements: SyntaxNode[],
@@ -85,11 +98,26 @@ function collectStatements(
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
-  const addCall = (key: string, node: SyntaxNode) => {
+  const addCall = (key: string, node: SyntaxNode, children?: CallStep[]) => {
     const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({ type: "call", key, ...locFromNode(file, node) });
+    steps.push({
+      type: "call",
+      key,
+      ...locFromNode(file, node),
+      ...(children && children.length > 0 ? { children } : {}),
+    });
+  };
+
+  // Lambda arguments of THIS call only — lambdas under a nested call belong to it.
+  const findLambdaArgs = (node: SyntaxNode, into: SyntaxNode[]): void => {
+    if (node.type === "call_expression") return;
+    if (node.type === "lambda_literal" || node.type === "anonymous_function") {
+      into.push(node);
+      return;
+    }
+    for (const child of namedChildren(node)) findLambdaArgs(child, into);
   };
 
   const pushIfChain = (node: SyntaxNode, asElseIf: boolean): void => {
@@ -225,12 +253,28 @@ function collectStatements(
     }
 
     if (node.type === "call_expression") {
-      const callee = node.namedChild(0);
+      // `f(args) { lambda }` parses as call_expression(call_expression(f, args), lambda):
+      // unwrap to the innermost callee, keeping every suffix level's arguments.
+      const argSubtrees: SyntaxNode[] = [...namedChildren(node).slice(1)];
+      let callee = node.namedChild(0);
+      while (callee?.type === "call_expression") {
+        argSubtrees.push(...namedChildren(callee).slice(1));
+        callee = callee.namedChild(0);
+      }
       if (callee) {
         const key = calleeKey(callee, className);
-        if (key) addCall(key, node);
+        if (key) {
+          const lambdas: SyntaxNode[] = [];
+          for (const subtree of argSubtrees) findLambdaArgs(subtree, lambdas);
+          const children = lambdas.flatMap((lambda) =>
+            collectStatements(file, lambdaBodyStatements(lambda), className),
+          );
+          addCall(key, node, children);
+        }
       }
-      for (const child of namedChildren(node).slice(1)) walk(child);
+      // Nested calls in arguments stay siblings; lambda bodies were claimed
+      // above and `walk` still skips lambda nodes, so nothing double-counts.
+      for (const subtree of argSubtrees) walk(subtree);
       return;
     }
 

--- a/test/kotlin.test.ts
+++ b/test/kotlin.test.ts
@@ -248,3 +248,112 @@ test("kotlin: companion object and object methods", ({ expectCallstack }) => {
     +    └─ more()
   `);
 });
+
+test("kotlin: trailing-lambda body nests under the receiving call", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+    + fun outer() {
+    +   runBlocking {
+    +     work()
+    +   }
+    + }
+      fun work() {}
+    `,
+    "outer",
+    { file: "lambda.kt" },
+  ).toEqual(`
+      outer()
+    + └─ runBlocking()
+    +    └─ work()
+  `);
+});
+
+test("kotlin: nested trailing lambdas nest transitively", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+    + fun outer() {
+    +   wrap {
+    +     use {
+    +       work()
+    +     }
+    +   }
+    + }
+      fun work() {}
+    `,
+    "outer",
+    { file: "nested-lambda.kt" },
+  ).toEqual(`
+      outer()
+    + └─ wrap()
+    +    └─ use()
+    +       └─ work()
+  `);
+});
+
+test("kotlin: parenthesized lambda argument nests under the call", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+    + fun outer() {
+    +   submit(3, { work() })
+    + }
+      fun work() {}
+    `,
+    "outer",
+    { file: "paren-lambda.kt" },
+  ).toEqual(`
+      outer()
+    + └─ submit()
+    +    └─ work()
+  `);
+});
+
+test("kotlin: call added inside an existing lambda diffs as an added child", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      fun outer() {
+        runBlocking {
+          work()
+    +     extra()
+        }
+      }
+      fun work() {}
+    + fun extra() {}
+    `,
+    "outer",
+    { file: "lambda-diff.kt" },
+  ).toEqual(`
+      outer()
+      └─ runBlocking()
+         ├─ work()
+    +    └─ extra()
+  `);
+});
+
+test("kotlin: args plus trailing lambda keeps the call and nests the body", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+    + fun outer(roots: List<String>) {
+    +   store.read(roots) { row ->
+    +     handle(row)
+    +   }
+    + }
+      fun handle(row: String) {}
+    `,
+    "outer",
+    { file: "args-lambda.kt" },
+  ).toEqual(`
+      outer(roots)
+    + └─ store.read()
+    +    └─ handle(row)
+  `);
+});


### PR DESCRIPTION
Kotlin lambda bodies were invisible to call trees, which hides most call flow in coroutine- and scope-function-heavy codebases (`runBlocking { }`, `use { }`, `forEach { }` everywhere). This PR fixes that plus a second, pre-existing loss it uncovered.

## 1. Lambda arguments now nest as call-site children

Lambda/anonymous-function bodies passed as call arguments execute as part of the enclosing call flow, so they now nest under the receiving call — reusing the same inline-children mechanism JSX children already use, so diff/reach/render need no engine changes:

```
outer()
└─ runBlocking()
   └─ work()
```

Deferred lambdas (`val f = { … }`) and named local functions stay hidden, preserving the existing "anonymous callbacks are not addressable" policy and its test.

## 2. `f(args) { lambda }` no longer drops the call entirely

Pre-existing on main: tree-sitter-kotlin parses args-plus-trailing-lambda as `call_expression(call_expression(f, args), lambda)`, `calleeKey` couldn't see through the inner call, and the whole call vanished from trees — `store.read(root) { row -> … }` produced nothing. The callee now unwraps through nested call levels, keeping every suffix level's arguments.

## Real-world before/after

On a large Kotlin codebase (SAP connector work), the tree for a submit method went from ending blind at `runBlocking()` to:

```
ODataSinkConnector.submitStaged(...)
└─ runBlocking()
   ├─ rejectOrphanedChildren()
   ├─ stagingStore.read()
   │  ├─ assembler.document()
   │  └─ httpClient.createEntity()
   └─ logger.info()
```

— and a reviewer's "this function is defined but nobody calls it" false alarm (the caller was inside a wrapper lambda) became visible as an added edge in `diff`.

## Tests

5 new cases in `test/kotlin.test.ts` (trailing lambda, nested trailing lambdas, parenthesized lambda argument, args-plus-lambda, added-call-inside-lambda diff); all 7 pre-existing Kotlin tests pass unchanged, including the `val f = { }` skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
