### PR TITLE
feat: add Perl language extractor (tree-sitter-perl)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # calldiff
 
-`calldiff` is a CLI for agentic code review: it diffs call stacks across git commits for 22 languages (AST-based, powered by tree-sitter). See `README.md` for usage and `## Dev` for the dev command.
+`calldiff` is a CLI for agentic code review: it diffs call stacks across git commits for 23 languages (AST-based, powered by tree-sitter). See `README.md` for usage and `## Dev` for the dev command.
 
 ## Cursor Cloud specific instructions
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Diff call stacks across git commits — like `git diff`, but for who-calls-whom.
 
-Built for **agentic code review**: when an agent (or you) rewires call flow, plain line diffs bury the shape of the change. `calldiff` shows which callees appeared, disappeared, or moved under an entrypoint — across **22 languages**.
+Built for **agentic code review**: when an agent (or you) rewires call flow, plain line diffs bury the shape of the change. `calldiff` shows which callees appeared, disappeared, or moved under an entrypoint — across **23 languages**.
 
 ```diff
   PiService.createAgentSession(options)
@@ -119,7 +119,7 @@ Prints every call path from the entrypoint to the target (including alternate `i
 
 ### Supported languages
 
-TypeScript, TSX, JavaScript, JSX, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml.
+TypeScript, TSX, JavaScript, JSX, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP, Kotlin, Swift, Scala, Lua, Elixir, Bash, Haskell, Zig, Solidity, OCaml, Perl.
 
 ## Output
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calldiff",
   "version": "0.6.0",
-  "description": "Diff call stacks across git commits for agentic code review (22 languages)",
+  "description": "Diff call stacks across git commits for agentic code review (23 languages)",
   "type": "module",
   "exports": {
     ".": {

--- a/skills/calldiff/SKILL.md
+++ b/skills/calldiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: calldiff
-description: Diff call stacks across git commits — like git diff, but for who-calls-whom. Shows which callees appeared, disappeared, or moved under an entrypoint across 22 languages (diff, tree, and reach). Use for agentic code review when call flow changed and line diffs bury the shape of the change.
+description: Diff call stacks across git commits — like git diff, but for who-calls-whom. Shows which callees appeared, disappeared, or moved under an entrypoint across 23 languages (diff, tree, and reach). Use for agentic code review when call flow changed and line diffs bury the shape of the change.
 requires_bin: calldiff
 command: calldiff
 ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,7 +124,7 @@ const pathsArg = z
 
 export const cli = Cli.create("calldiff", {
   description:
-    "Diff call stacks across git commits for agentic code review (22 languages)",
+    "Diff call stacks across git commits for agentic code review (23 languages)",
   version: readVersion(),
   hint: "Commands: diff (compare two trees), tree (view one tree), reach (paths between symbols). Path filters are trailing positionals (a leading -- is also accepted). Use --format json for structured agent output.",
   sync: {

--- a/src/languages/perl.ts
+++ b/src/languages/perl.ts
@@ -1,0 +1,545 @@
+/**
+ * Perl callable extraction (tree-sitter-perl).
+ *
+ * Quirks: paren-less calls with args parse as
+ * ambiguous_function_call_expression; zero-arg ones as a bare bareword
+ * statement. `package Foo;` scopes until the next package statement,
+ * `package Foo { }` only its block.
+ */
+import type { CallStep, FunctionInfo } from "../types.js";
+import {
+  childByType,
+  collapseWs,
+  locFromNode,
+  namedChildren,
+  type LanguageExtractor,
+  type SyntaxNode,
+  type Tree,
+} from "./types.js";
+
+type Scope = {
+  readonly file: string;
+  readonly packageName: string | null;
+};
+
+// "My::App::log" -> { pkg: "My::App", name: "log" }
+// "foo" -> { pkg: null, name: "foo" }
+function splitQualified(text: string) {
+  const idx = text.lastIndexOf("::");
+  if (idx === -1) return { pkg: null, name: text };
+
+  const pkg = text.slice(0, idx);
+  const name = text.slice(idx + 2);
+
+  return { pkg, name };
+}
+
+// ("Foo::Bar", "baz") -> "Foo.Bar.baz"
+// (null, "bar") -> "bar"
+function packageKey(packageName: string | null, name: string) {
+  if (packageName === null) return name;
+
+  const normalizedPackage = packageName.replaceAll("::", ".");
+  return `${normalizedPackage}.${name}`;
+}
+
+function normalizePackage(name: string | null) {
+  return name === "main" ? null : name;
+}
+
+// ("Thing", "new") -> "new Thing" (constructor alias, skipped by entry inference)
+// ("Thing", "run") -> "Thing.run"
+function methodKey(packageName: string | null, name: string) {
+  if (packageName !== null && name === "new") {
+    return `new ${packageName.replaceAll("::", ".")}`;
+  }
+
+  return packageKey(packageName, name);
+}
+
+const SIGILS = new Map([
+  ["scalar", "$"],
+  ["array", "@"],
+  ["hash", "%"],
+]);
+
+function varWithSigil(node: SyntaxNode) {
+  const sigil = SIGILS.get(node.type);
+  const name = childByType(node, "varname")?.text;
+  if (sigil === undefined || name === undefined) return null;
+
+  return `${sigil}${name}`;
+}
+
+function isSelfLike(name: string) {
+  return name === "$self" || name === "$class";
+}
+
+// ($self, $x, @rest) nodes -> ["$x", "@rest"]
+function paramNames(variables: SyntaxNode[]) {
+  return variables
+    .map((variable) => varWithSigil(variable))
+    .filter((name) => name !== null)
+    .filter((name) => !isSelfLike(name));
+}
+
+// signature ($x, $y = 1, @rest) -> ["$x", "$y", "@rest"]
+function signatureParams(signature: SyntaxNode) {
+  return namedChildren(signature).map((parameter) => {
+    const variable = namedChildren(parameter).at(0);
+    if (variable === undefined) return "_";
+
+    return varWithSigil(variable) ?? "_";
+  });
+}
+
+// `my <left> = <right>;` statement -> { left, right }
+function assignmentOf(statement: SyntaxNode) {
+  if (statement.type !== "expression_statement") return null;
+
+  const assignment = namedChildren(statement).at(0);
+  if (assignment?.type !== "assignment_expression") return null;
+
+  const sides = namedChildren(assignment);
+  const left = sides.at(0);
+  const right = sides.at(1);
+  if (left?.type !== "variable_declaration" || right === undefined) return null;
+
+  return { left, right };
+}
+
+// `shift`, `shift @_` -> true, `shift @queue` -> false
+function shiftsArgs(right: SyntaxNode) {
+  if (right.type !== "func1op_call_expression") return false;
+  if (right.child(0)?.type !== "shift") return false;
+
+  const operand = namedChildren(right).at(0);
+  if (operand === undefined) return true;
+
+  return (
+    operand.type === "array" && childByType(operand, "varname")?.text === "_"
+  );
+}
+
+// [`my ($self, $x) = @_;`, ...] -> ["$x"]
+// [`my $a = shift;`, `my $b = shift;`, ...] -> ["$a", "$b"]
+function conventionalParams(statements: SyntaxNode[]): string[] {
+  const names: string[] = [];
+
+  for (const statement of statements) {
+    if (statement.type === "comment") continue;
+
+    const assignment = assignmentOf(statement);
+    if (assignment === null) break;
+
+    const { left, right } = assignment;
+
+    const unpacksArgs =
+      right.type === "array" && childByType(right, "varname")?.text === "_";
+    if (unpacksArgs) {
+      names.push(...paramNames(namedChildren(left)));
+      break;
+    }
+
+    if (!shiftsArgs(right)) break;
+
+    const declared = namedChildren(left).at(0);
+    if (declared !== undefined) names.push(...paramNames([declared]));
+  }
+
+  return names;
+}
+
+function formatParams(names: string[]) {
+  return `(${names.join(", ")})`;
+}
+
+function getParamsLabel(node: SyntaxNode, body: SyntaxNode | null) {
+  const signature = childByType(node, "signature");
+
+  if (signature !== null) {
+    const names = signatureParams(signature).filter((n) => !isSelfLike(n));
+    return formatParams(names);
+  }
+  if (body === null) return "()";
+
+  const names = conventionalParams(namedChildren(body));
+  return formatParams(names);
+}
+
+// ("foo", "Pkg") -> "Pkg.foo"
+// ("Util::log", any) -> "Util.log"
+function nameKey(text: string, packageName: string | null) {
+  const { pkg, name } = splitQualified(text);
+  if (pkg !== null) return packageKey(normalizePackage(pkg), name);
+
+  return packageKey(packageName, name);
+}
+
+// foo() -> "foo" | "Pkg.foo"
+// &foo() -> "foo"
+function calleeKey(node: SyntaxNode, packageName: string | null) {
+  const fn = childByType(node, "function");
+  if (fn === null) return null;
+
+  const text = childByType(fn, "varname")?.text ?? fn.text;
+  if (text === "" || text.startsWith("$")) return null;
+
+  return nameKey(text, packageName);
+}
+
+// $self->m -> "Pkg.m"
+// Foo::Bar->m -> "Foo.Bar.m"
+function methodCallKey(node: SyntaxNode, packageName: string | null) {
+  const receiver = namedChildren(node).at(0);
+  const method = childByType(node, "method");
+  if (receiver === undefined || method === null) return null;
+
+  const rawName = method.text;
+  if (rawName === "" || rawName.startsWith("$")) return null; // computed: $obj->$m
+
+  if (rawName.startsWith("SUPER::")) {
+    return methodKey(packageName, rawName.slice("SUPER::".length));
+  }
+
+  const { pkg: methodPkg, name: prop } = splitQualified(rawName);
+  if (methodPkg !== null) return methodKey(normalizePackage(methodPkg), prop);
+
+  switch (receiver.type) {
+    case "scalar": {
+      const name = childByType(receiver, "varname")?.text;
+      if (name === undefined) return null;
+      if (name === "self" || name === "class") {
+        return methodKey(packageName, prop);
+      }
+      return `${name}.${prop}`;
+    }
+    case "bareword":
+      return methodKey(normalizePackage(receiver.text), prop);
+    default:
+      // __PACKAGE__ and chained/complex receivers: package-scope fallback
+      return methodKey(packageName, prop);
+  }
+}
+
+// `new Foo(1)`, `new Foo` target -> "Foo", else null
+function constructedClass(target: SyntaxNode) {
+  let text: string | null = null;
+  if (target.type === "bareword") text = target.text;
+  if (target.type === "function_call_expression") {
+    text = childByType(target, "function")?.text ?? null;
+  }
+  if (text === null || text === "" || text.startsWith("$")) return null;
+
+  return text;
+}
+
+function keywordToken(node: SyntaxNode, keywords: string[]) {
+  const token = node.children.find((c) => !c.isNamed && keywords.includes(c.type));
+  return token?.type ?? null;
+}
+
+const NON_CONDITION_TYPES = new Set(["block", "elsif", "else", "comment"]);
+
+function conditionOf(node: SyntaxNode) {
+  const condition = namedChildren(node).find((c) => !NON_CONDITION_TYPES.has(c.type));
+  return condition ?? null;
+}
+
+const TRY_KEYWORDS = new Set(["try", "catch", "finally"]);
+
+function callStep(scope: Scope, key: string, node: SyntaxNode) {
+  return {
+    type: "call",
+    key,
+    ...locFromNode(scope.file, node),
+  } satisfies CallStep;
+}
+
+function branchStep(
+  scope: Scope,
+  key: string,
+  label: string,
+  cond: SyntaxNode | null,
+  anchor: SyntaxNode,
+  children: CallStep[],
+) {
+  const text = cond === null ? "" : collapseWs(cond.text);
+
+  return {
+    type: "branch",
+    key: text === "" ? key : `${key}:${text}`,
+    label: text === "" ? label : `${label} ${text}`,
+    ...locFromNode(scope.file, cond ?? anchor),
+    children,
+  } satisfies CallStep;
+}
+
+function collectStatements(scope: Scope, statements: SyntaxNode[]) {
+  return statements.flatMap((statement) => collectNode(scope, statement));
+}
+
+function collectBlock(scope: Scope, block: SyntaxNode | null) {
+  if (block === null) return [];
+  return collectStatements(scope, namedChildren(block));
+}
+
+// zero-arg paren-less call (`helper;`, `helper if $x;`) -> lone bareword
+function collectExpression(scope: Scope, node: SyntaxNode): CallStep[] {
+  if (node.type === "bareword") {
+    return [callStep(scope, nameKey(node.text, scope.packageName), node)];
+  }
+
+  return collectNode(scope, node);
+}
+
+function collectNode(scope: Scope, node: SyntaxNode): CallStep[] {
+  switch (node.type) {
+    case "subroutine_declaration_statement":
+    case "method_declaration_statement":
+    case "anonymous_subroutine_expression":
+      return [];
+    case "conditional_statement":
+      return collectConditional(scope, node);
+    case "postfix_conditional_expression":
+      return collectPostfixConditional(scope, node);
+    case "try_statement":
+      return collectTryStatement(scope, node);
+    case "eval_expression":
+      return collectEval(scope, node);
+    case "function_call_expression":
+    case "ambiguous_function_call_expression":
+      return collectFunctionCall(scope, node);
+    case "method_call_expression":
+      return collectMethodCall(scope, node);
+    // map, grep, sort block: callback, not caller body
+    case "map_grep_expression":
+    case "sort_expression":
+      return namedChildren(node)
+        .filter((c) => c.type !== "block")
+        .flatMap((c) => collectNode(scope, c));
+    case "expression_statement":
+      return namedChildren(node).flatMap((c) => collectExpression(scope, c));
+    case "assignment_expression": {
+      const kids = namedChildren(node);
+      const right = kids.at(-1);
+      return kids.flatMap((c) =>
+        c === right ? collectExpression(scope, c) : collectNode(scope, c),
+      );
+    }
+    case "return_expression":
+      return namedChildren(node).flatMap((c) => collectExpression(scope, c));
+    default:
+      return collectStatements(scope, namedChildren(node));
+  }
+}
+
+function collectConditional(scope: Scope, node: SyntaxNode) {
+  const keyword = keywordToken(node, ["if", "unless"]) ?? "if";
+  const head = branchStep(
+    scope,
+    keyword,
+    keyword,
+    conditionOf(node),
+    node,
+    collectBlock(scope, childByType(node, "block")),
+  );
+  const clauses = namedChildren(node).flatMap((clause) =>
+    collectClause(scope, clause),
+  );
+
+  return [head, ...clauses];
+}
+
+// elsif chains nest in the CST
+function collectClause(scope: Scope, clause: SyntaxNode): CallStep[] {
+  if (clause.type === "elsif") {
+    const head = branchStep(
+      scope,
+      "else-if",
+      "elsif",
+      conditionOf(clause),
+      clause,
+      collectBlock(scope, childByType(clause, "block")),
+    );
+    const nested = namedChildren(clause).flatMap((next) =>
+      collectClause(scope, next),
+    );
+
+    return [head, ...nested];
+  }
+  if (clause.type === "else") {
+    const body = collectBlock(scope, childByType(clause, "block"));
+    return [branchStep(scope, "else", "else", null, clause, body)];
+  }
+
+  return [];
+}
+
+function collectPostfixConditional(scope: Scope, node: SyntaxNode) {
+  const keyword = keywordToken(node, ["if", "unless"]) ?? "if";
+  const kids = namedChildren(node).filter((c) => c.type !== "comment");
+  const expression = kids.at(0);
+  const condition = kids.at(1) ?? null;
+  const children =
+    expression === undefined ? [] : collectExpression(scope, expression);
+
+  return [branchStep(scope, keyword, keyword, condition, node, children)];
+}
+
+// keyword tokens precede blocks; catch var left out of keys (not rename-stable)
+function collectTryStatement(scope: Scope, node: SyntaxNode) {
+  const children = node.children;
+
+  return children.flatMap((child, index) => {
+    if (child.type !== "block") return [];
+
+    const keyword = children
+      .slice(0, index)
+      .reverse()
+      .find((c) => !c.isNamed && TRY_KEYWORDS.has(c.type));
+    const kind = keyword?.type ?? "try";
+    const body = collectStatements(scope, namedChildren(child));
+
+    return [branchStep(scope, kind, kind, null, keyword ?? node, body)];
+  });
+}
+
+// eval { ... } -> "try" branch; string eval (no block) -> no branch
+function collectEval(scope: Scope, node: SyntaxNode) {
+  const block = childByType(node, "block");
+  if (block === null) return collectStatements(scope, namedChildren(node));
+
+  const body = collectBlock(scope, block);
+
+  return [branchStep(scope, "try", "eval", null, node, body)];
+}
+
+function collectFunctionCall(scope: Scope, node: SyntaxNode) {
+  const fn = childByType(node, "function");
+  const io = childByType(node, "indirect_object");
+  const fnText = fn?.text;
+
+  // legacy indirect-object constructor (always paren-less): `new Foo(1)` -> `Foo->new(1)`
+  if (node.type === "ambiguous_function_call_expression" && fnText === "new") {
+    const target = namedChildren(node).find((c) => c !== fn);
+    const cls = target === undefined ? null : constructedClass(target);
+    if (target !== undefined && cls !== null) {
+      const constructorArgSteps =
+        target.type === "function_call_expression"
+          ? namedChildren(target)
+              .filter((c) => c.type !== "function")
+              .flatMap((c) => collectNode(scope, c))
+          : [];
+      return [
+        callStep(scope, methodKey(normalizePackage(cls), "new"), node),
+        ...constructorArgSteps,
+      ];
+    }
+  }
+
+  // indirect_object block (`helper { ... } 3`): callback, not caller body
+  const key = calleeKey(node, scope.packageName);
+  const argumentSteps = namedChildren(node)
+    .filter((c) => c !== fn && c !== io)
+    .flatMap((c) => collectNode(scope, c));
+
+  if (key === null) return argumentSteps;
+
+  return [callStep(scope, key, node), ...argumentSteps];
+}
+
+function collectMethodCall(scope: Scope, node: SyntaxNode) {
+  const method = childByType(node, "method");
+  const key = methodCallKey(node, scope.packageName);
+  const receiverAndArgSteps = namedChildren(node)
+    .filter((c) => c !== method)
+    .flatMap((c) => collectNode(scope, c));
+
+  if (key === null) return receiverAndArgSteps;
+
+  return [callStep(scope, key, node), ...receiverAndArgSteps];
+}
+
+// sub greet in Foo -> { key: "Foo.greet", label: "Foo.greet($name)", ... }
+// sub new in Foo -> primary "Foo.new" plus constructor alias "new Foo"
+function functionInfos(
+  file: string,
+  node: SyntaxNode,
+  packageName: string | null,
+): FunctionInfo[] {
+  const nameNode = childByType(node, "bareword");
+  if (nameNode === null) return [];
+
+  const body = childByType(node, "block");
+
+  const { pkg: inlinePkg, name } = splitQualified(nameNode.text);
+  const pkg = inlinePkg === null ? packageName : normalizePackage(inlinePkg);
+  const key = packageKey(pkg, name);
+  const isConstructor = pkg !== null && name === "new";
+  const labelBase = isConstructor ? methodKey(pkg, name) : key;
+
+  const info = {
+    key,
+    label: `${labelBase}${getParamsLabel(node, body)}`,
+    file,
+    steps: collectBlock({ file, packageName: pkg }, body),
+    exported: !name.startsWith("_"),
+    start: node.startIndex,
+    end: node.endIndex,
+  } satisfies FunctionInfo;
+
+  if (!isConstructor) return [info];
+
+  return [info, { ...info, key: labelBase }];
+}
+
+// [`package Foo;`, `sub a`, `sub b`] -> [Foo.a, Foo.b]
+// [`package Foo { sub a }`, `sub b`] -> [Foo.a, b]
+function definitionsIn(
+  file: string,
+  statements: SyntaxNode[],
+  packageName: string | null,
+): FunctionInfo[] {
+  const out: FunctionInfo[] = [];
+  let currentPackage = packageName;
+
+  for (const statement of statements) {
+    if (
+      statement.type === "package_statement" ||
+      statement.type === "class_statement"
+    ) {
+      const declared = normalizePackage(
+        childByType(statement, "package")?.text ?? null,
+      );
+      const block = childByType(statement, "block");
+
+      if (block === null) {
+        currentPackage = declared;
+      } else {
+        out.push(...definitionsIn(file, namedChildren(block), declared));
+      }
+      continue;
+    }
+
+    if (
+      statement.type === "subroutine_declaration_statement" ||
+      statement.type === "method_declaration_statement"
+    ) {
+      out.push(...functionInfos(file, statement, currentPackage));
+    }
+  }
+
+  return out;
+}
+
+function extractFromTree(file: string, _source: string, tree: Tree) {
+  return definitionsIn(file, namedChildren(tree.rootNode), null);
+}
+
+export const perlExtractor: LanguageExtractor = {
+  id: "perl",
+  extensions: [".pl", ".pm", ".t"],
+  grammarPackage: "tree-sitter-perl",
+  extract: extractFromTree,
+};

--- a/src/languages/registry.ts
+++ b/src/languages/registry.ts
@@ -12,6 +12,7 @@ import { javascriptExtractor, javascriptreactExtractor } from "./javascript.js";
 import { kotlinExtractor } from "./kotlin.js";
 import { luaExtractor } from "./lua.js";
 import { ocamlExtractor } from "./ocaml.js";
+import { perlExtractor } from "./perl.js";
 import { phpExtractor } from "./php.js";
 import { pythonExtractor } from "./python.js";
 import { rubyExtractor } from "./ruby.js";
@@ -49,6 +50,7 @@ const extractors: LanguageExtractor[] = [
   zigExtractor,
   solidityExtractor,
   ocamlExtractor,
+  perlExtractor,
 ];
 
 const byExtension = new Map<string, LanguageExtractor>();

--- a/test/perl.test.ts
+++ b/test/perl.test.ts
@@ -1,0 +1,447 @@
+import { test } from "./expectCallstack.js";
+
+test("perl: refactors calls into a helper with if/else", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      sub create_agent_session {
+          my ($options) = @_;
+      -   AuthStorage::create();
+      -   create_coding_tools();
+      +   my $services = get_services;
+      +   $services->boot();
+          if ($options->{session_id}) {
+              SessionManager::open($options->{session_id});
+          } else {
+              SessionManager::create();
+          }
+      }
+
+      + sub get_services {
+      +     AuthStorage::create();
+      +     create_coding_tools();
+      + }
+
+      sub create_coding_tools { }
+
+      sub AuthStorage::create { }
+      sub SessionManager::create { }
+      sub SessionManager::open { my ($id) = @_; }
+    `,
+    "create_agent_session",
+    { file: "pi.pl" },
+  ).toEqual(`
+      create_agent_session($options)
+    - ├─ AuthStorage.create()
+    - ├─ create_coding_tools()
+    + ├─ get_services()
+    + │  ├─ AuthStorage.create()
+    + │  └─ create_coding_tools()
+    + ├─ services.boot()
+      ├─ if $options->{session_id}
+         └─ SessionManager.open($id)
+      └─ else
+         └─ SessionManager.create()
+  `);
+});
+
+test("perl: $self->method resolves to Package.method", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      package Runner;
+
+      sub start {
+          my ($self) = @_;
+          $self->prepare();
+      +   $self->validate();
+          $self->run();
+      }
+
+      sub prepare { }
+      + sub validate { }
+      sub run { }
+    `,
+    "Runner.start",
+    { file: "runner.pm" },
+  ).toEqual(`
+      Runner.start()
+      ├─ Runner.prepare()
+    + ├─ Runner.validate()
+      └─ Runner.run()
+  `);
+});
+
+test("perl: qualified dispatch and nested packages resolve to dotted keys", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      package My::App::Base;
+
+      sub init { my ($self) = @_; log_init(); }
+      sub log_init { }
+
+      package My::App::Child;
+
+      sub create {
+          my ($self) = @_;
+      -   $self->setup();
+      +   $self->My::App::Base::init();
+      +   $self->SUPER::finish();
+      +   Util::Log::emit();
+      }
+
+      - sub setup { my ($self) = @_; }
+
+      package Util::Log;
+
+      + sub emit { }
+    `,
+    "Child.create",
+    { file: "app.pm" },
+  ).toEqual(`
+      My.App.Child.create()
+    - ├─ My.App.Child.setup()
+    + ├─ My.App.Base.init()
+    + │  └─ My.App.Base.log_init()
+    + ├─ My.App.Child.finish()
+    + └─ Util.Log.emit()
+  `);
+});
+
+test("perl: paren-less, &sigil, and postfix-conditional calls resolve like plain calls", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      sub main_loop {
+      -   setup();
+      +   setup;
+          run_once;
+          &init_hooks();
+      +   Log::flush;
+          cleanup if $done;
+      }
+
+      sub setup { }
+      sub run_once { }
+      sub init_hooks { }
+      + sub Log::flush { }
+      sub cleanup { }
+    `,
+    "main_loop",
+    { file: "calls.pl" },
+  ).toEqual(`
+      main_loop()
+      ├─ setup()
+      ├─ run_once()
+      ├─ init_hooks()
+    + ├─ Log.flush()
+      └─ if $done
+         └─ cleanup()
+  `);
+});
+
+test("perl: indirect-object new matches Class->new; plain new(...) stays a call", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      sub make {
+      -   my $w = new Thing(load_config());
+      +   my $w = Thing->new(load_config());
+      +   register($w);
+          new(helper());
+      }
+
+      sub load_config { }
+      + sub register { }
+      sub helper { }
+
+      package Thing;
+
+      sub new {
+          my ($class, $config) = @_;
+          my $self = bless {}, $class;
+          $self->init();
+      +   ready() unless $config->{bare};
+          return $self;
+      }
+
+      sub init { my ($self) = @_; }
+      + sub ready { }
+    `,
+    "make",
+    { file: "ctor.pl" },
+  ).toEqual(`
+      make()
+      ├─ new Thing($config)
+      │  ├─ Thing.bless()
+      │  ├─ Thing.init()
+    + │  └─ unless $config->{bare}
+    + │     └─ Thing.ready()
+      ├─ load_config()
+    + ├─ register()
+      ├─ new()
+      └─ helper()
+  `);
+});
+
+test("perl: subroutine signatures drive the params label", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      use v5.36;
+
+      sub notify ($user, $message, @tags) {
+          format_message($message, @tags);
+      +   deliver($user);
+      }
+
+      sub format_message ($message, @tags) { }
+      + sub deliver ($user) { }
+    `,
+    "notify",
+    { file: "notify.pl" },
+  ).toEqual(`
+      notify($user, $message, @tags)
+      ├─ format_message($message, @tags)
+    + └─ deliver($user)
+  `);
+});
+
+test("perl: shift @_ unpacks conventional params; comments and other arrays do not", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      sub enqueue {
+          # take the next job
+          my $self = shift;
+          my $job = shift @_;
+          my $next = shift @queue;
+          process($job);
+      +   audit($job);
+      }
+
+      sub process { my ($job) = @_; }
+      + sub audit { my ($job) = @_; }
+    `,
+    "enqueue",
+    { file: "queue.pl" },
+  ).toEqual(`
+      enqueue($job)
+      ├─ process($job)
+    + └─ audit($job)
+  `);
+});
+
+test("perl: package block scopes methods and unless branches", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      package Cache {
+          sub get {
+              my ($self, $key) = @_;
+              unless ($self->{$key}) {
+      -           $self->reload($key);
+      +           $self->fetch($key);
+              }
+              return $self->{$key};
+          }
+
+      -   sub reload { my ($self, $key) = @_; }
+      +   sub fetch { my ($self, $key) = @_; }
+      }
+    `,
+    "Cache.get",
+    { file: "cache.pm" },
+  ).toEqual(`
+      Cache.get($key)
+      └─ unless $self->{$key}
+    -    ├─ Cache.reload($key)
+    +    └─ Cache.fetch($key)
+  `);
+});
+
+test("perl: 5.38 class methods resolve like package subs", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      use v5.38;
+      use experimental 'class';
+
+      class Counter {
+          field $count = 0;
+
+          method increment ($by = 1) {
+              $self->log_change();
+      +       $self->clamp();
+          }
+
+          method log_change {
+              audit($count);
+          }
+
+      +   method clamp { }
+
+          sub audit { my ($value) = @_; }
+      }
+    `,
+    "Counter.increment",
+    { file: "counter.pl" },
+  ).toEqual(`
+      Counter.increment($by)
+      ├─ Counter.log_change()
+      │  └─ Counter.audit($value)
+    + └─ Counter.clamp()
+  `);
+});
+
+test("perl: elsif chains stay flat; loop bodies attribute to the caller", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      sub handle {
+          my ($status, @jobs) = @_;
+          if ($status eq 'a') {
+              do_a();
+          } elsif ($status eq 'b') {
+              do_b();
+      +       do_extra();
+          } else {
+              do_other();
+          }
+          for my $job (@jobs) {
+              run_job($job);
+          }
+      }
+
+      sub do_a { }
+      sub do_b { }
+      + sub do_extra { }
+      sub do_other { }
+      sub run_job { my ($job) = @_; }
+    `,
+    "handle",
+    { file: "elsif.pl" },
+  ).toEqual(`
+      handle($status, @jobs)
+      ├─ if $status eq 'a'
+         └─ do_a()
+      ├─ elsif $status eq 'b'
+         ├─ do_b()
+    +    └─ do_extra()
+      ├─ else
+         └─ do_other()
+      └─ run_job($job)
+  `);
+});
+
+test("perl: try/catch/finally and eval as branches", ({ expectCallstack }) => {
+  expectCallstack(
+    `
+      use v5.40;
+
+      sub boot {
+          try {
+              open_();
+          } catch ($e) {
+              recover($e);
+          } finally {
+              close_();
+          }
+      -   risky();
+      +   eval { risky(); };
+      +   flush();
+      }
+
+      sub open_ { }
+      sub recover { my ($e) = @_; }
+      sub close_ { }
+      sub risky { }
+      + sub flush { }
+    `,
+    "boot",
+    { file: "ctrl.pl" },
+  ).toEqual(`
+      boot()
+      ├─ try
+         └─ open_()
+      ├─ catch
+         └─ recover($e)
+      ├─ finally
+         └─ close_()
+    - ├─ risky()
+    + ├─ eval
+    +    └─ risky()
+    + └─ flush()
+  `);
+});
+
+test("perl: expression-position Try::Tiny stays calls; blocks are callbacks", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      use Try::Tiny;
+
+      sub load_config {
+          my $config = try { read_file(); } catch { defaults(); };
+      +   validate($config);
+          return $config;
+      }
+
+      sub read_file { }
+      sub defaults { }
+      + sub validate { my ($config) = @_; }
+    `,
+    "load_config",
+    { file: "config.pl" },
+  ).toEqual(`
+      load_config()
+      ├─ try()
+      ├─ catch()
+    + └─ validate($config)
+  `);
+});
+
+test("perl: anonymous subs and block arguments are callbacks; a lone finally stays a call", ({
+  expectCallstack,
+}) => {
+  expectCallstack(
+    `
+      sub outer {
+          my $handler = sub { hidden(); };
+          with_retries { hidden(); } 3;
+          my @ready = map { hidden($_) } visible_list();
+          finally { hidden(); };
+          visible($handler);
+      +   also_visible();
+      }
+
+      sub hidden { }
+      sub with_retries { }
+      sub visible_list { }
+      sub finally { my ($cb) = @_; }
+      sub visible { my ($handler) = @_; }
+      + sub also_visible { }
+    `,
+    "outer",
+    { file: "nested.pl" },
+  ).toEqual(`
+      outer()
+      ├─ with_retries()
+      ├─ visible_list()
+      ├─ finally($cb)
+      ├─ visible($handler)
+    + └─ also_visible()
+  `);
+});


### PR DESCRIPTION
Adds Perl as the 23rd language (`.pl`, `.pm`, `.t`), following `src/languages/CONTRACT.md`.

## Perl-specific handling

- Scope and labels
  - `package Foo;` scopes until the next package statement, `package Foo { }` only its block; Perl 5.38 `class` with `method` resolves the same way
  - the params label comes from the signature when present, otherwise from the `my (...) = @_;` or `shift` prologue
- Call sites
  - paren-less calls in statement, postfix-conditional, assignment-RHS, and return positions
  - indirect-object `new Thing(...)`, resolving to the same key as `Thing->new(...)`
- Branches
  - block `eval` as a `try` branch, alongside native `try`, `catch`, and `finally`

## Notes

- builtins that parse as plain calls (`print`, `bless`, ...) appear package-qualified, same as Ruby's `Thing.puts`; a Perl-specific filter is out of scope

## Tests

13 tests in `test/perl.test.ts`; full suite (268 tests) and `tsc` pass.
