### PR TITLE
Fix branch-test call edges, repeated entry flags, call resolution state, and grammar installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,14 @@ TypeScript, TSX, JavaScript, JSX, Python, Go, Rust, Java, Ruby, C, C++, C#, PHP,
 3. Builds per-function callee lists and expands them into call trees
 4. Diffs the trees, prints a tree, or searches paths — plus structured output for agents
 
-Grammars install on first use (override cache with `CALLDIFF_GRAMMAR_CACHE`). This is syntactic (AST-based), not a full typechecker — dynamic calls won’t resolve.
+This is syntactic (AST-based), not a full typechecker — dynamic calls won’t resolve.
+
+### Grammars
+
+`tree-sitter-typescript` and `tree-sitter-javascript` are dependencies, so TypeScript, TSX, JavaScript and JSX work with nothing else installed. The other 18 grammar packages — every other language of the 22 — are fetched from npm on first use and built natively into `~/.cache/calldiff/grammars` (a few MB each).
+
+- `CALLDIFF_GRAMMAR_CACHE=<dir>` — install somewhere else.
+- `--offline` (or `CALLDIFF_OFFLINE=1`) — never install. A file whose grammar is missing is skipped with one warning on stderr, and every language that *can* be parsed still answers, so a mixed repository degrades per file rather than failing outright.
 
 ## Dev
 

--- a/src/calltree.ts
+++ b/src/calltree.ts
@@ -5,7 +5,12 @@ import {
   type FunctionIndex,
 } from "./extract.js";
 import { pickLoc } from "./loc.js";
-import type { CallNode, CallStep, FunctionInfo } from "./types.js";
+import type {
+  CallNode,
+  CallStep,
+  FunctionInfo,
+  SourceLoc,
+} from "./types.js";
 
 /** Normalize user-facing paths for entry matching (`\` → `/`, strip `./`). */
 export function normalizeEntryPath(entry: string): string {
@@ -188,6 +193,16 @@ function expandCall(
   const info = infoOverride ?? resolveCall(key, index, callSite, owner);
   const label = displayCallLabel(key, index, info);
 
+  // State the resolver computes anyway. Carried onto the node so a consumer can
+  // tell "no calls beneath it" from "not resolvable" from "cut off by the depth
+  // cap" without re-running at a deeper `--max-depth` and diffing the results.
+  const resolution = {
+    resolved: info !== undefined,
+    ...(info?.line != null
+      ? { declaredIn: pickLoc({ file: info.file, line: info.line }) as SourceLoc }
+      : {}),
+  };
+
   // Recursion is per definition, not per name: two same-named functions in
   // different files calling each other is not a cycle.
   const token = info ? fileScopedKey(info.file, info.key) : key;
@@ -199,11 +214,20 @@ function expandCall(
       : pickLoc(callSite);
 
   if (depth >= maxDepth) {
-    return { key, label, kind: "call", ...loc, children: [] };
+    const hasBody = Boolean(info?.steps.length) || Boolean(inlineChildren?.length);
+    return {
+      key,
+      label,
+      kind: "call",
+      ...loc,
+      ...resolution,
+      ...(hasBody ? { truncated: true as const } : {}),
+      children: [],
+    };
   }
 
   if (!info && !inlineChildren?.length) {
-    return { key, label, kind: "call", ...loc, children: [] };
+    return { key, label, kind: "call", ...loc, ...resolution, children: [] };
   }
 
   if (info && visiting.has(token)) {
@@ -216,6 +240,8 @@ function expandCall(
       label: `${label} ⇄`,
       kind: "call",
       ...loc,
+      ...resolution,
+      recursive: true,
       children: callSiteChildren,
     };
   }
@@ -234,6 +260,7 @@ function expandCall(
     label,
     kind: "call",
     ...loc,
+    ...resolution,
     children: [...bodyChildren, ...callSiteChildren],
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,6 +195,18 @@ const locsOption = z
   .default(false)
   .describe("Show call-site source locations (file:line)");
 
+/**
+ * Optional rather than `.default(false)` on purpose: absent has to stay
+ * distinguishable from `--no-offline`, so that an unset flag falls through to
+ * `CALLDIFF_OFFLINE` instead of silently overriding it.
+ */
+const offlineOption = z
+  .boolean()
+  .optional()
+  .describe(
+    "Never install a tree-sitter grammar; skip files whose grammar is missing",
+  );
+
 const pathsArg = z
   .array(z.string())
   .optional()
@@ -227,6 +239,7 @@ export const cli = Cli.create("calldiff", {
       file: fileOption.optional(),
       maxDepth: maxDepthOption,
       locs: locsOption,
+      offline: offlineOption,
       from: z.string().optional().describe('Left / "before" tree'),
       to: z.string().optional().describe('Right / "after" tree'),
     }),
@@ -275,6 +288,7 @@ export const cli = Cli.create("calldiff", {
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
           locs: c.options.locs,
+          offline: c.options.offline,
           color: !c.formatExplicit && !c.agent,
         });
       } catch (error) {
@@ -315,6 +329,7 @@ export const cli = Cli.create("calldiff", {
       file: fileOption.optional(),
       maxDepth: maxDepthOption,
       locs: locsOption,
+      offline: offlineOption,
     }),
     alias: { entry: "e", file: "F" },
     examples: [
@@ -351,6 +366,7 @@ export const cli = Cli.create("calldiff", {
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
           locs: c.options.locs,
+          offline: c.options.offline,
           color: !c.formatExplicit && !c.agent,
         });
         return emitAsciiOrData(c, result);
@@ -380,6 +396,7 @@ export const cli = Cli.create("calldiff", {
         .describe("Target symbol to reach (functionName or ClassName.method)"),
       maxDepth: maxDepthOption,
       locs: locsOption,
+      offline: offlineOption,
     }),
     alias: { entry: "e", file: "F" },
     examples: [
@@ -424,6 +441,7 @@ export const cli = Cli.create("calldiff", {
           paths: c.args.paths,
           maxDepth: c.options.maxDepth,
           locs: c.options.locs,
+          offline: c.options.offline,
           color: !c.formatExplicit && !c.agent,
         });
         return emitAsciiOrData(c, result);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,15 +41,93 @@ export function hasTokenFlag(argv: string[]): boolean {
  */
 let tokenFlagActive = false;
 
-/** Strip lone `--` so `calldiff a b -- src` still works with incur. */
+/** Long/short spellings of the options that may be repeated. */
+const REPEATABLE = {
+  entry: ["--entry", "-e"],
+  file: ["--file", "-F"],
+} as const;
+
+type Repeatable = keyof typeof REPEATABLE;
+
+/**
+ * Values of repeated `--entry` / `--file` flags, in the order written.
+ *
+ * Both options are declared `z.union([z.string(), z.array(z.string())])` so a
+ * structured caller (MCP, HTTP) can send either shape, and incur's parser only
+ * accumulates repeats for a field whose *own* type is `z.array` — a union is
+ * not one, so `-e a -e b` overwrote and silently kept `b`. Narrowing the schema
+ * to an array would fix the CLI by breaking every caller that passes a bare
+ * string, so the repeats are collected here instead and the published schema
+ * stays true. Collected per `normalizeArgv` call; empty for non-argv callers,
+ * who keep going through the parsed option.
+ */
+let repeatedOptions: Record<Repeatable, string[]> = { entry: [], file: [] };
+
+/**
+ * Strip lone `--` so `calldiff a b -- src` still works with incur, and record
+ * repeated `--entry` / `--file` values.
+ */
 export function normalizeArgv(argv: string[]): string[] {
   tokenFlagActive = hasTokenFlag(argv);
-  return argv.filter((token) => token !== "--");
+  const tokens = argv.filter((token) => token !== "--");
+  repeatedOptions = collectRepeated(tokens);
+  return tokens;
+}
+
+const REPEATABLE_ENTRIES = Object.entries(REPEATABLE) as Array<
+  [Repeatable, readonly string[]]
+>;
+
+/**
+ * Scan post-`--`-strip tokens for repeated option values, matching how incur
+ * reads them: `--flag value`, `--flag=value`, `-f value`. `-f=value` is not a
+ * form incur accepts, so it is not one here either.
+ *
+ * One left-to-right pass, consuming each value as it goes, so that a value
+ * spelled like a flag (`--file -e`) is not read as one. Values of options this
+ * function does not know about are not skipped, which only matters if one is
+ * literally `-e` or `--entry`.
+ */
+export function collectRepeated(
+  tokens: string[],
+): Record<Repeatable, string[]> {
+  const found: Record<Repeatable, string[]> = { entry: [], file: [] };
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
+
+    const exact = REPEATABLE_ENTRIES.find(([, spellings]) =>
+      spellings.includes(token),
+    );
+    if (exact) {
+      const value = tokens[i + 1];
+      if (value !== undefined) {
+        found[exact[0]].push(value);
+        i += 1;
+      }
+      continue;
+    }
+
+    for (const [name, spellings] of REPEATABLE_ENTRIES) {
+      const long = spellings.find(
+        (flag) => flag.startsWith("--") && token.startsWith(`${flag}=`),
+      );
+      if (long) {
+        found[name].push(token.slice(long.length + 1));
+        break;
+      }
+    }
+  }
+
+  return found;
 }
 
 function entriesFromOption(
   entry: string | string[] | undefined,
+  name: Repeatable,
 ): string[] | undefined {
+  const repeated = repeatedOptions[name];
+  if (repeated.length > 0) return repeated;
   if (entry === undefined) return undefined;
   return Array.isArray(entry) ? entry : [entry];
 }
@@ -185,8 +263,8 @@ export const cli = Cli.create("calldiff", {
     ],
     hint: "Semantics match git diff: no refs → HEAD vs worktree; one ref → that vs worktree; two refs → compare those trees.",
     run(c) {
-      const entries = entriesFromOption(c.options.entry);
-      const files = entriesFromOption(c.options.file);
+      const entries = entriesFromOption(c.options.entry, "entry");
+      const files = entriesFromOption(c.options.file, "file");
       let result: DiffResult;
       try {
         result = runDiff({
@@ -255,8 +333,8 @@ export const cli = Cli.create("calldiff", {
       },
     ],
     run(c) {
-      const entries = entriesFromOption(c.options.entry) ?? [];
-      const files = entriesFromOption(c.options.file) ?? [];
+      const entries = entriesFromOption(c.options.entry, "entry") ?? [];
+      const files = entriesFromOption(c.options.file, "file") ?? [];
       if (entries.length === 0 && files.length === 0) {
         return c.error({
           code: "MISSING_ENTRY",
@@ -320,8 +398,8 @@ export const cli = Cli.create("calldiff", {
       },
     ],
     run(c) {
-      const entries = entriesFromOption(c.options.entry) ?? [];
-      const files = entriesFromOption(c.options.file) ?? [];
+      const entries = entriesFromOption(c.options.entry, "entry") ?? [];
+      const files = entriesFromOption(c.options.file, "file") ?? [];
       if (entries.length === 0 && files.length === 0) {
         return c.error({
           code: "MISSING_ENTRY",

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -16,12 +16,16 @@ function grammarKey(npmPackage: string, grammarExport?: string): string {
   return grammarExport ? `${npmPackage}:${grammarExport}` : npmPackage;
 }
 
-function loadLanguage(npmPackage: string, grammarExport?: string): unknown {
+function loadLanguage(
+  npmPackage: string,
+  grammarExport?: string,
+  languageId?: string,
+): unknown {
   const key = grammarKey(npmPackage, grammarExport);
   const cached = languageCache.get(key);
   if (cached) return cached;
 
-  const mod = loadGrammarPackage(npmPackage);
+  const mod = loadGrammarPackage(npmPackage, languageId);
   const language = resolveLanguage(mod, grammarExport);
   languageCache.set(key, language);
   return language;
@@ -37,6 +41,7 @@ export function extractFunctions(
   const language = loadLanguage(
     extractor.grammarPackage,
     extractor.grammarExport,
+    extractor.id,
   );
   parser.setLanguage(language as any);
   const tree = parser.parse(source);

--- a/src/languages/CONTRACT.md
+++ b/src/languages/CONTRACT.md
@@ -26,6 +26,8 @@ Helpers: `namedChildren`, `childByType`, `collapseWs` from `./types.js`.
    its branch: `if (guard(x))` really calls `guard`, and a label is not an edge.
    Skipping this makes `tree` print a call that `reach` reports no path to.
    Loops (`while (guard(x))`) already get this by taking the ordinary path.
+   Same for a switch/match subject — `switch (getKind(x))` calls `getKind`
+   before any arm is chosen, so walk it once, before the case branches.
 5. Nested function/lambda bodies NOT attributed to outer caller
 6. Ignore computed/dynamic callees when obvious
 

--- a/src/languages/CONTRACT.md
+++ b/src/languages/CONTRACT.md
@@ -21,7 +21,11 @@ Helpers: `namedChildren`, `childByType`, `collapseWs` from `./types.js`.
 1. Free functions + type/class methods
 2. Calls: bare + member/receiver (`self`/`this`/recv → `Type.method`)
 3. Constructors / `new` analogue when the language has one
-4. if/else (and elif if present) as branches with source-text labels
+4. if/else (and elif if present) as branches with source-text labels. The test
+   expression is *also* walked for calls, emitted as steps immediately before
+   its branch: `if (guard(x))` really calls `guard`, and a label is not an edge.
+   Skipping this makes `tree` print a call that `reach` reports no path to.
+   Loops (`while (guard(x))`) already get this by taking the ordinary path.
 5. Nested function/lambda bodies NOT attributed to outer caller
 6. Ignore computed/dynamic callees when obvious
 

--- a/src/languages/bash.ts
+++ b/src/languages/bash.ts
@@ -159,6 +159,10 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
     }
 
     if (node.type === "case_statement") {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      addTestCalls(
+        namedChildren(node).find((c) => c.type !== "case_item") ?? null,
+      );
       for (const item of namedChildren(node)) {
         if (item.type !== "case_item") continue;
         const kids = namedChildren(item);

--- a/src/languages/bash.ts
+++ b/src/languages/bash.ts
@@ -75,6 +75,12 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test])) steps.push(step);
+  };
+
   const walk = (node: SyntaxNode): void => {
     // Nested function bodies are not attributed to the outer function
     if (node.type === "function_definition") return;
@@ -115,6 +121,7 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
       // If first kid is the condition already captured as test, drop it from consequent
       const thenStmts = consequent.filter((c) => c !== cond);
 
+      addTestCalls(test);
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",
@@ -129,6 +136,7 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
           childByType(clause, "test_command") ?? elifKids[0] ?? null;
         const text = elifTest ? collapseWs(elifTest.text) : "";
         const body = elifKids.filter((c) => c !== elifTest);
+        addTestCalls(elifTest);
         steps.push({
           type: "branch",
           key: text ? `else-if:${text}` : "else-if",

--- a/src/languages/c.ts
+++ b/src/languages/c.ts
@@ -180,6 +180,11 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
     }
 
     if (node.type === "switch_statement") {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      addTestCalls(
+        node.childForFieldName("condition") ??
+          childByType(node, "parenthesized_expression"),
+      );
       const body =
         node.childForFieldName("body") ??
         childByType(node, "compound_statement");

--- a/src/languages/c.ts
+++ b/src/languages/c.ts
@@ -109,6 +109,12 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test])) steps.push(step);
+  };
+
   const walk = (node: SyntaxNode): void => {
     // Nested function definitions (GCC extension) — skip bodies
     if (node.type === "function_definition") return;
@@ -124,6 +130,7 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
         ) ??
         null;
       const text = condText(cond);
+      addTestCalls(cond);
       steps.push({
         type: "branch",
         key: text ? `if:${text}` : "if",
@@ -149,6 +156,7 @@ function collectStatements(file: string, statements: SyntaxNode[]): CallStep[] {
                 c.type !== "else_clause",
             ) ??
             null;
+          addTestCalls(elifCond);
           steps.push({
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",

--- a/src/languages/cpp.ts
+++ b/src/languages/cpp.ts
@@ -97,6 +97,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode): void => {
     if (
       node.type === "function_definition" ||
@@ -122,6 +130,7 @@ function collectStatements(
         ) ??
         null;
       const text = condText(cond);
+      addTestCalls(cond);
       steps.push({
         type: "branch",
         key: text ? `if:${text}` : "if",
@@ -150,6 +159,7 @@ function collectStatements(
                 c.type !== "else_clause",
             ) ??
             null;
+          addTestCalls(elifCond);
           steps.push({
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -223,6 +223,12 @@ function collectStatements(
     }
 
     if (node.type === "switch_statement") {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      addTestCalls(
+        node.childForFieldName("value") ??
+          namedChildren(node).find((c) => c.type !== "switch_body") ??
+          null,
+      );
       const body =
         node.childForFieldName("body") ?? childByType(node, "switch_body");
       if (body) {

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -83,6 +83,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode): void => {
     if (
       node.type === "method_declaration" ||
@@ -105,6 +113,7 @@ function collectStatements(
         namedChildren(node).find((c, i) => i > 0) ??
         null;
       const text = condText(cond);
+      addTestCalls(cond);
       steps.push({
         type: "branch",
         key: text ? `if:${text}` : "if",
@@ -131,6 +140,7 @@ function collectStatements(
           const elifText = condText(elifCond);
           const elifCons =
             alternative.childForFieldName("consequence") ?? null;
+          addTestCalls(elifCond);
           steps.push({
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",

--- a/src/languages/elixir.ts
+++ b/src/languages/elixir.ts
@@ -158,6 +158,9 @@ function collectStatements(
           ? namedChildren(doBlock).filter((c) => c.type !== "else_block")
           : [];
         const elseBlock = doBlock ? childByType(doBlock, "else_block") : null;
+        // The condition runs before either arm, so its calls are emitted first.
+        // See CONTRACT.md "Must support" #4.
+        if (cond) walk(cond);
         steps.push({
           type: "branch",
           key: condText ? `if:${condText}` : "if",
@@ -174,8 +177,6 @@ function collectStatements(
             children: collectBody(file, elseBlock, moduleName),
           });
         }
-        // cond may contain calls — walk it
-        if (cond) walk(cond);
         return;
       }
       if (head && head.text === "case") {

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -89,6 +89,16 @@ function collectIf(
   const kind = asElseIf ? "else-if" : "if";
   const labelKind = asElseIf ? "else if" : "if";
 
+  // Everything before the block runs unconditionally: the condition, and the
+  // init statement in `if v, err := doThing(); err != nil`. Only the condition
+  // reaches the label, so without this both are calls no `reach` query can find.
+  // See CONTRACT.md "Must support" #4.
+  for (const pre of before) {
+    for (const step of collectStatements(file, [pre], receiverType)) {
+      steps.push(step);
+    }
+  }
+
   steps.push({
     type: "branch",
     key: condText ? `${kind}:${condText}` : kind,

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -176,6 +176,12 @@ function collectStatements(
             c.type !== "default_case",
         ) ?? null;
       const subjectText = subject ? collapseWs(subject.text) : "";
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      if (subject) {
+        for (const step of collectStatements(file, [subject], receiverType)) {
+          steps.push(step);
+        }
+      }
       for (const clause of kids) {
         if (clause.type === "expression_case" || clause.type === "type_case") {
           const expr =

--- a/src/languages/grammars.ts
+++ b/src/languages/grammars.ts
@@ -119,6 +119,34 @@ const INSTALL_SPEC: Record<string, string> = {
 };
 
 /**
+ * npm argv for installing one grammar into the cache.
+ *
+ * The install must be *recorded* in the cache's package.json. npm reconciles
+ * the installed tree against that file every time, so under the previous
+ * `--no-save` — against a package.json that listed no dependencies — each
+ * grammar pruned the one installed before it ("added 1 package, and removed 1
+ * package"). The cache only ever held the most recently used language, so a
+ * polyglot repository re-downloaded and natively rebuilt a grammar on every
+ * run, and concurrent installs could delete a grammar another process was
+ * loading. Exact versions, so installing one grammar cannot drift another.
+ */
+export function grammarInstallArgs(
+  cacheDir: string,
+  installSpec: string,
+): string[] {
+  return [
+    "install",
+    "--prefix",
+    cacheDir,
+    "--save-exact",
+    "--no-fund",
+    "--no-audit",
+    "--legacy-peer-deps",
+    installSpec,
+  ];
+}
+
+/**
  * Install an npm grammar package into the shared cache if missing, then require it.
  * Reuses the cache across CLI invocations.
  */
@@ -164,23 +192,10 @@ export function loadGrammarPackage(
       // when the cache path is not writable, and its bare `mkdir` errno was
       // the least informative thing a caller could be handed.
       ensureCachePackageJson(cacheDir);
-      execFileSync(
-        "npm",
-        [
-          "install",
-          "--prefix",
-          cacheDir,
-          "--no-save",
-          "--no-fund",
-          "--no-audit",
-          "--legacy-peer-deps",
-          installSpec,
-        ],
-        {
-          stdio: ["ignore", "pipe", "pipe"],
-          env: process.env,
-        },
-      );
+      execFileSync("npm", grammarInstallArgs(cacheDir, installSpec), {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      });
     } catch (err) {
       // Without this the caller sees the raw errno — `mkdir '/nonexistent'` —
       // and has to guess which grammar was being fetched, or that one was.

--- a/src/languages/grammars.ts
+++ b/src/languages/grammars.ts
@@ -23,6 +23,27 @@ export function grammarCacheDir(): string {
   return join(homedir(), ".cache", "calldiff", "grammars");
 }
 
+/** Set by `--offline`; unset falls back to the environment. */
+let offlineOverride: boolean | undefined;
+
+/**
+ * Decline the on-demand install.
+ *
+ * `CALLDIFF_GRAMMAR_CACHE` could already move where grammars are written, but
+ * nothing could say "do not write them at all" — so a caller that promised its
+ * own users offline operation, determinism, or that it installs nothing had no
+ * way to adopt calldiff. Pass `undefined` to fall back to `CALLDIFF_OFFLINE`.
+ */
+export function setGrammarOffline(offline: boolean | undefined): void {
+  offlineOverride = offline;
+}
+
+export function grammarsOffline(): boolean {
+  if (offlineOverride !== undefined) return offlineOverride;
+  const value = process.env.CALLDIFF_OFFLINE;
+  return value === "1" || value === "true";
+}
+
 function packageInstalled(cacheDir: string, npmPackage: string): boolean {
   return existsSync(join(cacheDir, "node_modules", npmPackage));
 }
@@ -101,7 +122,11 @@ const INSTALL_SPEC: Record<string, string> = {
  * Install an npm grammar package into the shared cache if missing, then require it.
  * Reuses the cache across CLI invocations.
  */
-export function loadGrammarPackage(npmPackage: string): GrammarModule {
+export function loadGrammarPackage(
+  npmPackage: string,
+  /** Language id, for error messages: "no grammar for python" beats the package. */
+  languageId?: string,
+): GrammarModule {
   // Prefer the app's own dependency when present (e.g. tree-sitter-typescript).
   try {
     const localRequire = createRequire(import.meta.url);
@@ -126,26 +151,44 @@ export function loadGrammarPackage(npmPackage: string): GrammarModule {
   }
 
   const cacheDir = grammarCacheDir();
+  const name = languageId ?? npmPackage;
   if (!packageInstalled(cacheDir, npmPackage)) {
-    ensureCachePackageJson(cacheDir);
+    if (grammarsOffline()) {
+      throw new Error(
+        `no grammar for ${name} available offline: ${npmPackage} is not bundled and not in ${cacheDir}. Install it there, or drop --offline / CALLDIFF_OFFLINE to fetch it on demand.`,
+      );
+    }
     const installSpec = INSTALL_SPEC[npmPackage] ?? npmPackage;
-    execFileSync(
-      "npm",
-      [
-        "install",
-        "--prefix",
-        cacheDir,
-        "--no-save",
-        "--no-fund",
-        "--no-audit",
-        "--legacy-peer-deps",
-        installSpec,
-      ],
-      {
-        stdio: ["ignore", "pipe", "pipe"],
-        env: process.env,
-      },
-    );
+    try {
+      // Inside the try: creating the cache directory is the step that fails
+      // when the cache path is not writable, and its bare `mkdir` errno was
+      // the least informative thing a caller could be handed.
+      ensureCachePackageJson(cacheDir);
+      execFileSync(
+        "npm",
+        [
+          "install",
+          "--prefix",
+          cacheDir,
+          "--no-save",
+          "--no-fund",
+          "--no-audit",
+          "--legacy-peer-deps",
+          installSpec,
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: process.env,
+        },
+      );
+    } catch (err) {
+      // Without this the caller sees the raw errno — `mkdir '/nonexistent'` —
+      // and has to guess which grammar was being fetched, or that one was.
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `failed to install grammar for ${name} (${installSpec}) into ${cacheDir}: ${message}`,
+      );
+    }
   }
 
   const require = createRequire(join(cacheDir, "package.json"));

--- a/src/languages/grammars.ts
+++ b/src/languages/grammars.ts
@@ -4,6 +4,8 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -118,6 +120,77 @@ const INSTALL_SPEC: Record<string, string> = {
     "@tree-sitter-grammars/tree-sitter-lua@0.2.0",
 };
 
+/** How long to wait for another process's install before giving up. */
+const LOCK_TIMEOUT_MS = 15 * 60_000;
+/** A lock older than this is assumed to be from a process that died. */
+const LOCK_STALE_MS = 15 * 60_000;
+const LOCK_POLL_MS = 250;
+
+/** Block this thread without spinning; installs are synchronous already. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function lockIsStale(lockPath: string, staleMs: number): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs > staleMs;
+  } catch {
+    // Vanished between the EEXIST and the stat: not stale, just gone.
+    return false;
+  }
+}
+
+/**
+ * Hold an exclusive lock on the grammar cache for the duration of `install`.
+ *
+ * npm is not safe to run concurrently against one `--prefix`: two processes
+ * writing the same `node_modules` collide with ENOTEMPTY, half-populated
+ * package directories, and `Cannot find module` for a package that is mid-copy.
+ * A consumer fanning calldiff out across a repository hits this, and so does
+ * this project's own test suite under vitest's file parallelism.
+ *
+ * `mkdir` is atomic and fails with EEXIST when the directory exists, which is
+ * the portable way to take a lock without a dependency. A lock left behind by
+ * a killed process is reclaimed once it goes stale, so a crash costs a wait,
+ * not a permanently wedged cache.
+ */
+export function withInstallLock(
+  cacheDir: string,
+  install: () => void,
+  options: { timeoutMs?: number; staleMs?: number; pollMs?: number } = {},
+): void {
+  const timeoutMs = options.timeoutMs ?? LOCK_TIMEOUT_MS;
+  const staleMs = options.staleMs ?? LOCK_STALE_MS;
+  const pollMs = options.pollMs ?? LOCK_POLL_MS;
+  const lockPath = join(cacheDir, ".install-lock");
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      mkdirSync(lockPath);
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      if (lockIsStale(lockPath, staleMs)) {
+        rmSync(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `timed out waiting for another calldiff process to finish installing grammars into ${cacheDir}. Remove ${lockPath} if no such process is running.`,
+        );
+      }
+      sleepSync(pollMs);
+    }
+  }
+
+  try {
+    install();
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
 /**
  * npm argv for installing one grammar into the cache.
  *
@@ -127,8 +200,7 @@ const INSTALL_SPEC: Record<string, string> = {
  * grammar pruned the one installed before it ("added 1 package, and removed 1
  * package"). The cache only ever held the most recently used language, so a
  * polyglot repository re-downloaded and natively rebuilt a grammar on every
- * run, and concurrent installs could delete a grammar another process was
- * loading. Exact versions, so installing one grammar cannot drift another.
+ * run. Exact versions, so installing one grammar cannot drift another.
  */
 export function grammarInstallArgs(
   cacheDir: string,
@@ -192,9 +264,14 @@ export function loadGrammarPackage(
       // when the cache path is not writable, and its bare `mkdir` errno was
       // the least informative thing a caller could be handed.
       ensureCachePackageJson(cacheDir);
-      execFileSync("npm", grammarInstallArgs(cacheDir, installSpec), {
-        stdio: ["ignore", "pipe", "pipe"],
-        env: process.env,
+      withInstallLock(cacheDir, () => {
+        // Re-check under the lock: whoever held it may have been installing
+        // this very grammar, in which case there is nothing left to do.
+        if (packageInstalled(cacheDir, npmPackage)) return;
+        execFileSync("npm", grammarInstallArgs(cacheDir, installSpec), {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: process.env,
+        });
       });
     } catch (err) {
       // Without this the caller sees the raw errno — `mkdir '/nonexistent'` —

--- a/src/languages/haskell.ts
+++ b/src/languages/haskell.ts
@@ -75,7 +75,18 @@ function collectFromMatch(file: string, match: SyntaxNode | null): CallStep[] {
   return collectExpr(file, body);
 }
 
-function collectExpr(file: string, node: SyntaxNode): CallStep[] {
+function collectExpr(
+  file: string,
+  node: SyntaxNode,
+  /**
+   * Whether a bare `variable` counts as a nullary call. True in statement
+   * position, where `authStorageCreate;` really is one. False when walking a
+   * branch test: `if x == 1` would otherwise report a call to the parameter
+   * `x`. Applications inside the test (`null (sessionId options)`) are
+   * unambiguous and still collected either way.
+   */
+  nullaryVariables = true,
+): CallStep[] {
   const steps: CallStep[] = [];
   const seen = new Set<string>();
 
@@ -104,6 +115,10 @@ function collectExpr(file: string, node: SyntaxNode): CallStep[] {
       const thenE = kids[1] ?? null;
       const elseE = kids[2] ?? null;
       const condText = cond ? collapseWs(cond.text) : "";
+      // See CONTRACT.md "Must support" #4.
+      if (cond) {
+        for (const step of collectExpr(file, cond, false)) steps.push(step);
+      }
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",
@@ -165,7 +180,12 @@ function collectExpr(file: string, node: SyntaxNode): CallStep[] {
 
     if (n.type === "variable") {
       // Bare variable used as expression in do-block is a call-ish nullary
-      if (n.text !== "return" && n.text !== "pure" && !isLikelyTypeName(n.text)) {
+      if (
+        nullaryVariables &&
+        n.text !== "return" &&
+        n.text !== "pure" &&
+        !isLikelyTypeName(n.text)
+      ) {
         addCall(n.text, n);
       }
       return;

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -94,6 +94,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode): void => {
     if (
       node.type === "method_declaration" ||
@@ -126,6 +134,9 @@ function collectStatements(
           : cond;
       const condText = condInner ? collapseWs(condInner.text) : "";
 
+      // The nested `else if` chain below re-collects through collectStatements,
+      // so its own test calls come back with it — only this test needs walking.
+      addTestCalls(condInner);
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -237,6 +237,8 @@ function collectStatements(
       node.type === "switch_expression" ||
       node.type === "switch_statement"
     ) {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      addTestCalls(childByType(node, "parenthesized_expression"));
       const body =
         childByType(node, "switch_block") ??
         childByType(node, "switch_body") ??

--- a/src/languages/javascript.ts
+++ b/src/languages/javascript.ts
@@ -154,6 +154,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walkExpr = (node: SyntaxNode): void => {
     const type = node.type;
 
@@ -175,6 +183,7 @@ function collectStatements(
       const elseClause = childByType(node, "else_clause");
       const cond = test ? condText(test) : "";
 
+      addTestCalls(test);
       steps.push({
         type: "branch",
         key: branchKey("if", cond),
@@ -201,6 +210,7 @@ function collectStatements(
                 c.type !== "else_clause",
             ) ?? null;
           const elseCond = elseTest ? condText(elseTest) : "";
+          addTestCalls(elseTest);
           steps.push({
             type: "branch",
             key: branchKey("else-if", elseCond),

--- a/src/languages/javascript.ts
+++ b/src/languages/javascript.ts
@@ -282,6 +282,9 @@ function collectStatements(
     }
 
     if (type === "switch_statement") {
+      // The subject runs before any arm — `switch (getKind(x))` calls
+      // `getKind`. See CONTRACT.md "Must support" #4.
+      addTestCalls(childByType(node, "parenthesized_expression"));
       const body = childByType(node, "switch_body");
       for (const clause of body ? namedChildren(body) : []) {
         if (clause.type === "switch_case") {

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -129,6 +129,13 @@ function collectStatements(
     const kind = asElseIf ? "else-if" : "if";
     const labelKind = asElseIf ? "else if" : "if";
 
+    // See CONTRACT.md "Must support" #4.
+    if (cond) {
+      for (const step of collectStatements(file, [cond], className)) {
+        steps.push(step);
+      }
+    }
+
     steps.push({
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -233,6 +233,13 @@ function collectStatements(
     }
 
     if (node.type === "when_expression") {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      const subject = childByType(node, "when_subject");
+      if (subject) {
+        for (const step of collectStatements(file, [subject], className)) {
+          steps.push(step);
+        }
+      }
       for (const entry of namedChildren(node)) {
         if (entry.type !== "when_entry") continue;
         const cond = childByType(entry, "when_condition");

--- a/src/languages/lua.ts
+++ b/src/languages/lua.ts
@@ -80,6 +80,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], typeName)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode): void => {
     if (
       node.type === "function_declaration" ||
@@ -99,6 +107,7 @@ function collectStatements(
             c.type !== "elseif_statement",
         ) ?? null;
       const condText = cond ? collapseWs(cond.text) : "";
+      addTestCalls(cond);
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",
@@ -112,6 +121,7 @@ function collectStatements(
           const elseifCond =
             namedChildren(clause).find((c) => c.type !== "block") ?? null;
           const text = elseifCond ? collapseWs(elseifCond.text) : "";
+          addTestCalls(elseifCond);
           steps.push({
             type: "branch",
             key: text ? `else-if:${text}` : "else-if",

--- a/src/languages/ocaml.ts
+++ b/src/languages/ocaml.ts
@@ -170,6 +170,11 @@ function collectExpr(
           (c) => c.type !== "then_clause" && c.type !== "else_clause",
         ) ?? null;
       const condText = cond ? collapseWs(cond.text) : "";
+      // See CONTRACT.md "Must support" #4. The nested `else if` chain below
+      // re-collects through collectExpr, so its test calls come back with it.
+      if (cond) {
+        for (const step of collectExpr(file, cond, moduleName)) steps.push(step);
+      }
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",

--- a/src/languages/ocaml.ts
+++ b/src/languages/ocaml.ts
@@ -143,6 +143,16 @@ function collectExpr(
           children: tryBody ? collectExpr(file, tryBody, moduleName) : [],
         });
       }
+      if (n.type === "match_expression") {
+        // The scrutinee runs before any arm. See CONTRACT.md "Must support" #4.
+        const subject =
+          namedChildren(n).find((c) => c.type !== "match_case") ?? null;
+        if (subject) {
+          for (const step of collectExpr(file, subject, moduleName)) {
+            steps.push(step);
+          }
+        }
+      }
       for (const clause of namedChildren(n)) {
         if (clause.type !== "match_case") continue;
         const kids = namedChildren(clause);

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -104,6 +104,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode): void => {
     if (
       node.type === "function_definition" ||
@@ -130,6 +138,7 @@ function collectStatements(
         ) ??
         null;
       const text = condText(cond);
+      addTestCalls(cond);
       steps.push({
         type: "branch",
         key: text ? `if:${text}` : "if",
@@ -158,6 +167,7 @@ function collectStatements(
               (c) => c.type !== "parenthesized_expression",
             ) ??
             null;
+          addTestCalls(elifCond);
           steps.push({
             type: "branch",
             key: elifText ? `else-if:${elifText}` : "else-if",
@@ -198,6 +208,7 @@ function collectStatements(
                   c.type !== "else_if_clause",
               ) ??
               null;
+            addTestCalls(elifCond);
             steps.push({
               type: "branch",
               key: elifText ? `else-if:${elifText}` : "else-if",

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -119,6 +119,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode): void => {
     // Nested defs / lambdas: do not attribute their bodies to the outer fn
     if (
@@ -139,6 +147,7 @@ function collectStatements(
             c.type !== "elif_clause",
         ) ?? null;
       const cond = condNode ? collapseWs(condNode.text) : "";
+      addTestCalls(condNode);
       steps.push({
         type: "branch",
         key: cond ? `if:${cond}` : "if",
@@ -152,6 +161,7 @@ function collectStatements(
           const elifCond =
             namedChildren(clause).find((c) => c.type !== "block") ?? null;
           const text = elifCond ? collapseWs(elifCond.text) : "";
+          addTestCalls(elifCond);
           steps.push({
             type: "branch",
             key: text ? `else-if:${text}` : "else-if",

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -187,6 +187,9 @@ function collectStatements(
       const subject =
         namedChildren(node).find((c) => c.type !== "block") ?? null;
       const subjectText = subject ? collapseWs(subject.text) : "";
+      // The subject runs before any arm — `match get_kind(x):` calls
+      // `get_kind`. See CONTRACT.md "Must support" #4.
+      addTestCalls(subject);
       const block = childByType(node, "block");
       for (const clause of block ? namedChildren(block) : []) {
         if (clause.type !== "case_clause") continue;

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -131,6 +131,14 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /** Branch tests are walked for calls too — see CONTRACT.md "Must support" #4. */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walk = (node: SyntaxNode, asStatement: boolean): void => {
     if (
       node.type === "method" ||
@@ -157,6 +165,7 @@ function collectStatements(
       const condText = cond ? collapseWs(cond.text) : "";
       const kind = node.type; // if | unless
 
+      addTestCalls(cond);
       steps.push({
         type: "branch",
         key: condText ? `${kind}:${condText}` : kind,
@@ -172,6 +181,7 @@ function collectStatements(
             elsifKids.find((c) => c.type !== "then" && c.type !== "else") ??
             null;
           const text = elsifCond ? collapseWs(elsifCond.text) : "";
+          addTestCalls(elsifCond);
           steps.push({
             type: "branch",
             key: text ? `else-if:${text}` : "else-if",

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -172,6 +172,14 @@ function collectStatements(
     }
 
     if (node.type === "match_expression") {
+      // The scrutinee runs before any arm. See CONTRACT.md "Must support" #4.
+      const subject =
+        namedChildren(node).find((c) => c.type !== "match_block") ?? null;
+      if (subject) {
+        for (const step of collectStatements(file, [subject], typeName)) {
+          steps.push(step);
+        }
+      }
       const block = childByType(node, "match_block");
       for (const arm of block ? namedChildren(block) : []) {
         if (arm.type !== "match_arm") continue;

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -122,6 +122,13 @@ function collectStatements(
     const kind = asElseIf ? "else-if" : "if";
     const labelKind = asElseIf ? "else if" : "if";
 
+    // See CONTRACT.md "Must support" #4.
+    if (cond) {
+      for (const step of collectStatements(file, [cond], typeName)) {
+        steps.push(step);
+      }
+    }
+
     steps.push({
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,

--- a/src/languages/scala.ts
+++ b/src/languages/scala.ts
@@ -105,6 +105,13 @@ function collectStatements(
     const kind = asElseIf ? "else-if" : "if";
     const labelKind = asElseIf ? "else if" : "if";
 
+    // See CONTRACT.md "Must support" #4.
+    if (condInner) {
+      for (const step of collectStatements(file, [condInner], typeName)) {
+        steps.push(step);
+      }
+    }
+
     steps.push({
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,

--- a/src/languages/scala.ts
+++ b/src/languages/scala.ts
@@ -215,6 +215,14 @@ function collectStatements(
     }
 
     if (node.type === "match_expression") {
+      // The scrutinee runs before any arm. See CONTRACT.md "Must support" #4.
+      const subject =
+        namedChildren(node).find((c) => c.type !== "case_block") ?? null;
+      if (subject) {
+        for (const step of collectStatements(file, [subject], typeName)) {
+          steps.push(step);
+        }
+      }
       const caseBlock = childByType(node, "case_block");
       for (const clause of caseBlock ? namedChildren(caseBlock) : []) {
         if (clause.type !== "case_clause") continue;

--- a/src/languages/solidity.ts
+++ b/src/languages/solidity.ts
@@ -123,6 +123,13 @@ function collectStatements(
       const condText = cond ? collapseWs(cond.text) : "";
       const thenNode = bodies[0] ? unwrapStatement(bodies[0]) : null;
       const elseNode = bodies[1] ? unwrapStatement(bodies[1]) : null;
+      // See CONTRACT.md "Must support" #4. The nested `else if` chain below
+      // re-collects through collectStatements, so its test calls come with it.
+      if (cond) {
+        for (const step of collectStatements(file, [cond], contractName)) {
+          steps.push(step);
+        }
+      }
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -188,6 +188,14 @@ function collectStatements(
     }
 
     if (node.type === "switch_statement") {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      const subject =
+        namedChildren(node).find((c) => c.type !== "switch_entry") ?? null;
+      if (subject) {
+        for (const step of collectStatements(file, [subject], className)) {
+          steps.push(step);
+        }
+      }
       for (const entry of namedChildren(node)) {
         if (entry.type !== "switch_entry") continue;
         const pattern = childByType(entry, "switch_pattern");

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -105,6 +105,13 @@ function collectStatements(
     const kind = asElseIf ? "else-if" : "if";
     const labelKind = asElseIf ? "else if" : "if";
 
+    // See CONTRACT.md "Must support" #4.
+    if (cond) {
+      for (const step of collectStatements(file, [cond], className)) {
+        steps.push(step);
+      }
+    }
+
     steps.push({
       type: "branch",
       key: condText ? `${kind}:${condText}` : kind,

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -150,6 +150,20 @@ function collectStatements(
     steps.push({ type: "call", key, ...locFromNode(file, node) });
   };
 
+  /**
+   * A branch test is consumed as the branch label; walk it for calls as well,
+   * or `tree` prints `if (guard(x))` while `reach` finds no path to `guard`.
+   * Emitted before the branch because the test runs before the arm — the shape
+   * `while (guard(x))` already has, loops taking the ordinary path.
+   * See CONTRACT.md "Must support" #4.
+   */
+  const addTestCalls = (test: SyntaxNode | null) => {
+    if (!test) return;
+    for (const step of collectStatements(file, [test], className)) {
+      steps.push(step);
+    }
+  };
+
   const walkExpr = (node: SyntaxNode): void => {
     const type = node.type;
 
@@ -171,6 +185,7 @@ function collectStatements(
       const elseClause = childByType(node, "else_clause");
       const cond = test ? condText(test) : "";
 
+      addTestCalls(test);
       steps.push({
         type: "branch",
         key: branchKey("if", cond),
@@ -197,6 +212,7 @@ function collectStatements(
                 c.type !== "else_clause",
             ) ?? null;
           const elseCond = elseTest ? condText(elseTest) : "";
+          addTestCalls(elseTest);
           steps.push({
             type: "branch",
             key: branchKey("else-if", elseCond),

--- a/src/languages/zig.ts
+++ b/src/languages/zig.ts
@@ -184,6 +184,14 @@ function collectStatements(
     }
 
     if (node.type === "switch_expression") {
+      // The subject runs before any arm. See CONTRACT.md "Must support" #4.
+      const subject =
+        namedChildren(node).find((c) => c.type !== "switch_case") ?? null;
+      if (subject) {
+        for (const step of collectStatements(file, [subject], typeName)) {
+          steps.push(step);
+        }
+      }
       for (const clause of namedChildren(node)) {
         if (clause.type !== "switch_case") continue;
         const kids = namedChildren(clause);

--- a/src/languages/zig.ts
+++ b/src/languages/zig.ts
@@ -99,6 +99,13 @@ function collectStatements(
         ) ?? null;
       const elseClause = childByType(node, "else_clause");
       const condText = cond ? collapseWs(cond.text) : "";
+      // See CONTRACT.md "Must support" #4. The nested `else if` chain below
+      // re-collects through collectStatements, so its test calls come with it.
+      if (cond) {
+        for (const step of collectStatements(file, [cond], typeName)) {
+          steps.push(step);
+        }
+      }
       steps.push({
         type: "branch",
         key: condText ? `if:${condText}` : "if",

--- a/src/reach.ts
+++ b/src/reach.ts
@@ -34,6 +34,10 @@ export function pathToTree(nodes: CallNode[]): CallNode {
     ...(head!.file ? { file: head!.file } : {}),
     ...(head!.line != null ? { line: head!.line } : {}),
     ...(head!.endLine != null ? { endLine: head!.endLine } : {}),
+    ...(head!.resolved != null ? { resolved: head!.resolved } : {}),
+    ...(head!.declaredIn ? { declaredIn: head!.declaredIn } : {}),
+    ...(head!.truncated ? { truncated: head!.truncated } : {}),
+    ...(head!.recursive ? { recursive: head!.recursive } : {}),
     children: rest.length > 0 ? [pathToTree(rest)] : [],
   };
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -189,6 +189,10 @@ function serializeCallNode(node: CallNode): CallNode {
     ...(node.file ? { file: node.file } : {}),
     ...(node.line != null ? { line: node.line } : {}),
     ...(node.endLine != null ? { endLine: node.endLine } : {}),
+    ...(node.resolved != null ? { resolved: node.resolved } : {}),
+    ...(node.declaredIn ? { declaredIn: node.declaredIn } : {}),
+    ...(node.truncated ? { truncated: node.truncated } : {}),
+    ...(node.recursive ? { recursive: node.recursive } : {}),
     children: node.children.map(serializeCallNode),
   };
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -22,6 +22,7 @@ import {
   inferEntries,
   resolveExplicitDiffEntries,
 } from "./infer.js";
+import { setGrammarOffline } from "./languages/grammars.js";
 import { collectPathsTo, findReachPaths } from "./reach.js";
 import { renderDiff, renderTree } from "./render.js";
 import type { ExtractionCache, FunctionIndex } from "./extract.js";
@@ -50,6 +51,8 @@ export type DiffRunOptions = {
   color?: boolean;
   /** When true, append file:line suffixes in ascii. Default: false */
   locs?: boolean;
+  /** Decline the on-demand grammar install. Unset falls back to CALLDIFF_OFFLINE. */
+  offline?: boolean;
 };
 
 export type TreeRunOptions = {
@@ -61,6 +64,8 @@ export type TreeRunOptions = {
   maxDepth?: number;
   color?: boolean;
   locs?: boolean;
+  /** Decline the on-demand grammar install. Unset falls back to CALLDIFF_OFFLINE. */
+  offline?: boolean;
 };
 
 export type ReachRunOptions = {
@@ -76,6 +81,8 @@ export type ReachRunOptions = {
   maxDepth?: number;
   color?: boolean;
   locs?: boolean;
+  /** Decline the on-demand grammar install. Unset falls back to CALLDIFF_OFFLINE. */
+  offline?: boolean;
 };
 
 function loadIndex(
@@ -220,6 +227,7 @@ export function runDiff(options: DiffRunOptions = {}): DiffResult {
   const locs = options.locs === true;
   const hasExplicit = entriesOpt.length > 0 || filesOpt.length > 0;
 
+  setGrammarOffline(options.offline);
   assertGitRepo(cwd);
 
   const {
@@ -334,6 +342,7 @@ export function runTree(options: TreeRunOptions): TreeResult {
   const symbols = options.entries ?? [];
   const files = options.files ?? [];
 
+  setGrammarOffline(options.offline);
   assertGitRepo(cwd);
 
   const { snapshot, paths } = resolveSnapshotAndPaths(
@@ -379,6 +388,7 @@ export function runReach(options: ReachRunOptions): ReachResult {
   const symbols = options.entries ?? [];
   const files = options.files ?? [];
 
+  setGrammarOffline(options.offline);
   assertGitRepo(cwd);
 
   const { snapshot, paths } = resolveSnapshotAndPaths(

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,22 @@ export interface CallNode {
   file?: string;
   line?: number;
   endLine?: number;
+  /**
+   * Did this call resolve to a definition in the indexed tree?
+   *
+   * Present on call nodes, absent on branches, which are not calls. Without it
+   * a childless leaf is three different facts in one shape: an unresolved
+   * callee (builtin, external package, dynamic), a resolved definition whose
+   * body was cut off by `--max-depth`, and a resolved definition that makes no
+   * calls. The resolver knows which; only the ASCII reader can afford not to.
+   */
+  resolved?: boolean;
+  /** Where that definition is declared. Present iff `resolved`. */
+  declaredIn?: SourceLoc;
+  /** Children omitted because `--max-depth` was reached, not because there are none. */
+  truncated?: true;
+  /** Re-entry into a definition already on the stack (rendered as a `⇄` suffix). */
+  recursive?: true;
   children: CallNode[];
 }
 

--- a/test/branch-conditions.test.ts
+++ b/test/branch-conditions.test.ts
@@ -155,6 +155,82 @@ describe("branch test calls end to end", () => {
   });
 });
 
+/**
+ * A switch/match subject is the same defect one node over: it runs before any
+ * arm is chosen, and the extractors that special-case `switch` returned without
+ * walking it. TypeScript never special-cased `switch`, so its subject was
+ * always an ordinary edge — this makes the rest agree with it.
+ */
+describe("calls in a switch or match subject", () => {
+  const switched = buildIndex(
+    extractFunctions(
+      "sw.ts",
+      `
+        export function getKind(x: number): string { return "a"; }
+        export function target(): number { return 42; }
+        export function viaSwitch(x: number): number {
+          switch (getKind(x)) {
+            case "a": return target();
+            default: return 0;
+          }
+        }
+      `,
+    ),
+  );
+
+  test("typescript reaches the subject", () => {
+    expect(findReachPaths("viaSwitch", "getKind", switched, 12)).toHaveLength(1);
+  });
+
+  test("javascript reaches the subject", () => {
+    const js = buildIndex(
+      extractFunctions(
+        "sw.js",
+        `
+          export function getKind(x) { return "a"; }
+          export function target() { return 42; }
+          export function viaSwitch(x) {
+            switch (getKind(x)) {
+              case "a": return target();
+              default: return 0;
+            }
+          }
+        `,
+      ),
+    );
+    expect(findReachPaths("viaSwitch", "getKind", js, 12)).toHaveLength(1);
+    // The arms are still branches, not flattened into the subject's siblings.
+    const tree = buildCallTree("viaSwitch", js, 12);
+    expect(tree.children.map((c) => c.kind)).toEqual([
+      "call",
+      "branch",
+      "branch",
+    ]);
+  });
+
+  test("python reaches the match subject", () => {
+    const py = buildIndex(
+      extractFunctions(
+        "sw.py",
+        outdent`
+          def get_kind(x):
+              return "a"
+
+          def target():
+              return 42
+
+          def via_match(x):
+              match get_kind(x):
+                  case "a":
+                      return target()
+              return 0
+        `,
+      ),
+    );
+    expect(findReachPaths("via_match", "get_kind", py, 12)).toHaveLength(1);
+  });
+});
+
 /** Not a TypeScript quirk: every extractor consumed the test as label text. */
 describe("branch test calls in other languages", () => {
   test("python: elif and if tests both resolve", () => {

--- a/test/branch-conditions.test.ts
+++ b/test/branch-conditions.test.ts
@@ -1,0 +1,187 @@
+import { outdent } from "outdent";
+import { describe, expect, test } from "vitest";
+import { buildCallTree } from "../src/calltree.js";
+import { buildIndex, extractFunctions } from "../src/extract.js";
+import { findReachPaths } from "../src/reach.js";
+import { renderTree } from "../src/render.js";
+import { workspace } from "./workspace.js";
+
+/**
+ * A call in a branch test is an edge, not just label text.
+ *
+ * `tree` rendered `if (guard(x))` into the branch label and dropped the call,
+ * so `reach` answered "No paths" for a path the same tool had just printed —
+ * the worst direction for a consumer, since exit 0 plus "No paths" reads as a
+ * confident statement about absence. See CONTRACT.md "Must support" #4.
+ */
+const forms = `
+  export function guard(x: number): boolean { return x > 0; }
+  export function target(): number { return 42; }
+
+  export function viaIf(x: number): number {
+    if (guard(x)) { return target(); }
+    return 0;
+  }
+  export function viaElseIf(x: number): number {
+    if (x === 0) { return 1; }
+    else if (guard(x)) { return target(); }
+    return 0;
+  }
+  export function viaWhile(x: number): number {
+    while (guard(x)) { x--; }
+    return target();
+  }
+  export function viaTernary(x: number): number {
+    return guard(x) ? target() : 0;
+  }
+  export function viaAnd(x: number): number {
+    return guard(x) && target();
+  }
+  export function viaAssign(x: number): number {
+    const ok = guard(x);
+    if (ok) return target();
+    return 0;
+  }
+  export function viaReturn(x: number): boolean {
+    return guard(x);
+  }
+`;
+
+const index = buildIndex(extractFunctions("forms.ts", forms));
+
+function reaches(entry: string, to: string): boolean {
+  return findReachPaths(entry, to, index, 12).length > 0;
+}
+
+describe("calls in a branch test", () => {
+  test("reach finds the callee in an if test", () => {
+    expect(reaches("viaIf", "guard")).toBe(true);
+  });
+
+  test("reach finds the callee in an else-if test", () => {
+    expect(reaches("viaElseIf", "guard")).toBe(true);
+  });
+
+  // The forms that already worked; this fix must not disturb them.
+  test.each([
+    ["viaWhile", "while"],
+    ["viaTernary", "ternary"],
+    ["viaAnd", "&&"],
+    ["viaAssign", "assigned then tested"],
+    ["viaReturn", "returned"],
+  ])("still reaches through %s (%s)", (entry) => {
+    expect(reaches(entry, "guard")).toBe(true);
+  });
+
+  test("the condition call is a sibling of the branch, as while already was", () => {
+    const ascii = renderTree(buildCallTree("viaIf", index, 12), {
+      color: false,
+    });
+    expect(ascii).toBe(
+      outdent`
+        viaIf(x)
+        ├─ guard(x)
+        └─ if (guard(x))
+           └─ target()
+      `,
+    );
+
+    // Same shape the ordinary path has always produced for a loop condition.
+    expect(renderTree(buildCallTree("viaWhile", index, 12), { color: false }))
+      .toBe(
+        outdent`
+          viaWhile(x)
+          ├─ guard(x)
+          └─ target()
+        `,
+      );
+  });
+
+  test("the branch label still shows the condition", () => {
+    const ascii = renderTree(buildCallTree("viaIf", index, 12), {
+      color: false,
+    });
+    expect(ascii).toContain("if (guard(x))");
+  });
+
+  test("a test with no calls adds no steps", () => {
+    const plain = buildIndex(
+      extractFunctions(
+        "plain.ts",
+        `
+          export function run(x: number): number {
+            if (x > 0) { return work(); }
+            return 0;
+          }
+          export function work(): number { return 1; }
+        `,
+      ),
+    );
+    expect(renderTree(buildCallTree("run", plain, 12), { color: false })).toBe(
+      outdent`
+        run(x)
+        └─ if (x > 0)
+           └─ work()
+      `,
+    );
+  });
+});
+
+describe("branch test calls end to end", () => {
+  test("reach reports the path the tree prints", () => {
+    const host = workspace({
+      "/src/app.ts": outdent`
+        export function guard(x: number): boolean {
+          return x > 0;
+        }
+
+        export function viaIf(x: number): number {
+          if (guard(x)) {
+            return 1;
+          }
+          return 0;
+        }
+      `,
+    });
+
+    const result = host.run("calldiff reach -e viaIf --to guard -- src");
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(outdent`
+      viaIf(x)
+      └─ guard(x)
+    `);
+    expect(result.stdout).not.toContain("No paths");
+  });
+});
+
+/** Not a TypeScript quirk: every extractor consumed the test as label text. */
+describe("branch test calls in other languages", () => {
+  test("python: elif and if tests both resolve", () => {
+    const py = buildIndex(
+      extractFunctions(
+        "a.py",
+        outdent`
+          def guard(x):
+              return x > 0
+
+          def other(x):
+              return x < 0
+
+          def target():
+              return 42
+
+          def via_if(x):
+              if guard(x):
+                  return target()
+              elif other(x):
+                  return 0
+              return 1
+        `,
+      ),
+    );
+
+    expect(findReachPaths("via_if", "guard", py, 12)).toHaveLength(1);
+    expect(findReachPaths("via_if", "other", py, 12)).toHaveLength(1);
+  });
+});

--- a/test/haskell.test.ts
+++ b/test/haskell.test.ts
@@ -35,6 +35,8 @@ sessionId _ = Nothing
     + ├─ getServices()
     + │  ├─ authStorageCreate()
     + │  └─ createCodingTools()
+      ├─ null()
+      ├─ sessionId(_)
       ├─ if null (sessionId options)
          └─ sessionManagerCreate()
       └─ else

--- a/test/offline.test.ts
+++ b/test/offline.test.ts
@@ -1,0 +1,148 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { outdent } from "outdent";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  grammarsOffline,
+  setGrammarOffline,
+} from "../src/languages/grammars.js";
+import { workspace } from "./workspace.js";
+
+/**
+ * `CALLDIFF_GRAMMAR_CACHE` could move where on-demand grammars are written,
+ * but nothing could decline the write, so a caller that had promised its own
+ * users offline operation could not adopt calldiff. The only opt-out was to
+ * point the cache at an uncreatable path, which stopped the install and then
+ * reported a bare `mkdir` errno naming neither the grammar nor the cause.
+ */
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  setGrammarOffline(undefined);
+  delete process.env.CALLDIFF_OFFLINE;
+  while (scratchDirs.length > 0) {
+    rmSync(scratchDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+/** A cache path that does not exist yet, so an install shows up on disk. */
+function scratchCache(): string {
+  const parent = mkdtempSync(join(tmpdir(), "calldiff-offline-"));
+  scratchDirs.push(parent);
+  return join(parent, "grammars");
+}
+
+describe("grammarsOffline", () => {
+  test("is off by default", () => {
+    expect(grammarsOffline()).toBe(false);
+  });
+
+  test("reads CALLDIFF_OFFLINE", () => {
+    process.env.CALLDIFF_OFFLINE = "1";
+    expect(grammarsOffline()).toBe(true);
+    process.env.CALLDIFF_OFFLINE = "true";
+    expect(grammarsOffline()).toBe(true);
+    process.env.CALLDIFF_OFFLINE = "0";
+    expect(grammarsOffline()).toBe(false);
+  });
+
+  test("an explicit setting wins over the environment", () => {
+    process.env.CALLDIFF_OFFLINE = "1";
+    setGrammarOffline(false);
+    expect(grammarsOffline()).toBe(false);
+    setGrammarOffline(true);
+    expect(grammarsOffline()).toBe(true);
+  });
+
+  test("clearing the setting falls back to the environment", () => {
+    process.env.CALLDIFF_OFFLINE = "1";
+    setGrammarOffline(false);
+    setGrammarOffline(undefined);
+    expect(grammarsOffline()).toBe(true);
+  });
+});
+
+const python = outdent`
+  def sink(x):
+      print(x)
+
+  def main():
+      sink(1)
+`;
+
+const ts = outdent`
+  export function boot(): void {
+    helper();
+  }
+  export function helper(): void {}
+`;
+
+describe("--offline", () => {
+  test("installs nothing, and names the grammar and the way out", () => {
+    const cache = scratchCache();
+    const host = workspace({ "/a.py": python });
+
+    const result = host.run("calldiff tree --entry main --offline", {
+      env: { CALLDIFF_GRAMMAR_CACHE: cache },
+    });
+
+    expect(existsSync(cache)).toBe(false);
+    expect(result.stderr).toContain("python");
+    expect(result.stderr).toContain("tree-sitter-python");
+    expect(result.stderr).toContain("--offline");
+  });
+
+  test("CALLDIFF_OFFLINE declines the install too", () => {
+    const cache = scratchCache();
+    const host = workspace({ "/a.py": python });
+
+    const result = host.run("calldiff tree --entry main", {
+      env: { CALLDIFF_GRAMMAR_CACHE: cache, CALLDIFF_OFFLINE: "1" },
+    });
+
+    expect(existsSync(cache)).toBe(false);
+    expect(result.stderr).toContain("tree-sitter-python");
+  });
+
+  test("a mixed repo still answers for the languages it can parse", () => {
+    const cache = scratchCache();
+    const host = workspace({ "/a.py": python, "/b.ts": ts });
+
+    const result = host.run("calldiff tree --entry boot --offline", {
+      env: { CALLDIFF_GRAMMAR_CACHE: cache },
+    });
+
+    // Python is skipped with exactly one warning; TypeScript is a dependency
+    // and answers normally. Per-file degradation, unchanged.
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("boot()");
+    expect(result.stdout).toContain("helper()");
+    expect(result.stderr.trim().split("\n")).toHaveLength(1);
+    expect(result.stderr).toContain("a.py");
+    expect(result.stdout).not.toContain("warn:");
+    expect(existsSync(cache)).toBe(false);
+  });
+
+  test("bundled grammars are unaffected by the flag", () => {
+    const host = workspace({ "/b.ts": ts });
+
+    const offline = host.run("calldiff tree --entry boot --offline");
+    const online = host.run("calldiff tree --entry boot");
+
+    expect(offline.code).toBe(0);
+    expect(offline.stdout).toBe(online.stdout);
+    expect(offline.stderr).toBe("");
+  });
+
+  test("a failed install names the grammar instead of a raw errno", () => {
+    const host = workspace({ "/a.py": python });
+
+    const result = host.run("calldiff tree --entry main", {
+      env: { CALLDIFF_GRAMMAR_CACHE: "/nonexistent-calldiff-cache" },
+    });
+
+    expect(result.stderr).toContain("failed to install grammar for python");
+    expect(result.stderr).toContain("tree-sitter-python");
+  });
+});

--- a/test/offline.test.ts
+++ b/test/offline.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { outdent } from "outdent";
 import { afterEach, describe, expect, test } from "vitest";
 import {
+  grammarInstallArgs,
   grammarsOffline,
   setGrammarOffline,
 } from "../src/languages/grammars.js";
@@ -60,6 +61,25 @@ describe("grammarsOffline", () => {
     setGrammarOffline(false);
     setGrammarOffline(undefined);
     expect(grammarsOffline()).toBe(true);
+  });
+});
+
+/**
+ * The cache is only a cache if it accumulates. npm reconciles the tree against
+ * the cache's package.json on every install, so `--no-save` against a
+ * package.json listing nothing made each grammar prune the one before it.
+ */
+describe("grammarInstallArgs", () => {
+  test("records the install so npm cannot prune the other grammars", () => {
+    const args = grammarInstallArgs("/cache", "tree-sitter-python");
+    expect(args).toContain("--save-exact");
+    expect(args).not.toContain("--no-save");
+  });
+
+  test("installs into the given cache", () => {
+    const args = grammarInstallArgs("/cache", "tree-sitter-c-sharp@0.23.1");
+    expect(args.slice(0, 3)).toEqual(["install", "--prefix", "/cache"]);
+    expect(args.at(-1)).toBe("tree-sitter-c-sharp@0.23.1");
   });
 });
 

--- a/test/offline.test.ts
+++ b/test/offline.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { outdent } from "outdent";
@@ -7,6 +7,7 @@ import {
   grammarInstallArgs,
   grammarsOffline,
   setGrammarOffline,
+  withInstallLock,
 } from "../src/languages/grammars.js";
 import { workspace } from "./workspace.js";
 
@@ -80,6 +81,71 @@ describe("grammarInstallArgs", () => {
     const args = grammarInstallArgs("/cache", "tree-sitter-c-sharp@0.23.1");
     expect(args.slice(0, 3)).toEqual(["install", "--prefix", "/cache"]);
     expect(args.at(-1)).toBe("tree-sitter-c-sharp@0.23.1");
+  });
+});
+
+/**
+ * npm is not safe to run concurrently against one `--prefix`. Two calldiff
+ * processes installing different grammars into a shared cache collided with
+ * ENOTEMPTY and half-copied package directories — which a consumer fanning
+ * calldiff out across a repository hits, and which this suite hit under
+ * vitest's file parallelism.
+ */
+describe("withInstallLock", () => {
+  function lockDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "calldiff-lock-"));
+    scratchDirs.push(dir);
+    return dir;
+  }
+
+  test("runs the install and releases the lock", () => {
+    const dir = lockDir();
+    let ran = 0;
+    withInstallLock(dir, () => {
+      ran += 1;
+      expect(existsSync(join(dir, ".install-lock"))).toBe(true);
+    });
+    expect(ran).toBe(1);
+    expect(existsSync(join(dir, ".install-lock"))).toBe(false);
+  });
+
+  test("releases the lock when the install throws", () => {
+    const dir = lockDir();
+    expect(() =>
+      withInstallLock(dir, () => {
+        throw new Error("install blew up");
+      }),
+    ).toThrow("install blew up");
+    expect(existsSync(join(dir, ".install-lock"))).toBe(false);
+  });
+
+  test("waits for a held lock and gives up with an actionable message", () => {
+    const dir = lockDir();
+    mkdirSync(join(dir, ".install-lock"));
+    let ran = false;
+
+    expect(() =>
+      withInstallLock(dir, () => { ran = true; }, {
+        timeoutMs: 50,
+        pollMs: 5,
+        staleMs: 60_000,
+      }),
+    ).toThrow(/timed out waiting for another calldiff process/);
+    expect(ran).toBe(false);
+  });
+
+  test("reclaims a lock left behind by a dead process", () => {
+    const dir = lockDir();
+    const lock = join(dir, ".install-lock");
+    mkdirSync(lock);
+    const longAgo = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lock, longAgo, longAgo);
+
+    let ran = false;
+    withInstallLock(dir, () => { ran = true; }, { staleMs: 1000, pollMs: 5 });
+
+    expect(ran).toBe(true);
+    expect(existsSync(lock)).toBe(false);
   });
 });
 

--- a/test/repeated-options.test.ts
+++ b/test/repeated-options.test.ts
@@ -1,0 +1,151 @@
+import { outdent } from "outdent";
+import { describe, expect, test } from "vitest";
+import { collectRepeated, normalizeArgv } from "../src/cli.js";
+import { workspace } from "./workspace.js";
+
+/**
+ * `--entry` / `--file` accept multiple values in the published schema
+ * (`anyOf: string | string[]`) and in the README's usage line
+ * (`-e PiService.createAgentSession -e boot`), but incur only accumulates
+ * repeats for a plain `z.array` field. Against a union it overwrote, so all
+ * but the last value vanished without a word.
+ */
+describe("collectRepeated", () => {
+  test("collects repeated long and short spellings", () => {
+    expect(collectRepeated(["tree", "-e", "a", "--entry", "b"])).toEqual({
+      entry: ["a", "b"],
+      file: [],
+    });
+    expect(collectRepeated(["tree", "-F", "x.ts", "--file", "y.ts"])).toEqual({
+      entry: [],
+      file: ["x.ts", "y.ts"],
+    });
+  });
+
+  test("collects the --flag=value form", () => {
+    expect(collectRepeated(["tree", "--entry=a", "--entry=b"])).toEqual({
+      entry: ["a", "b"],
+      file: [],
+    });
+  });
+
+  test("does not mistake a flag's value for a flag", () => {
+    // `-e` here is the value of `--file`, not an entry flag.
+    expect(collectRepeated(["tree", "--file", "-e", "--entry", "b"])).toEqual({
+      entry: ["b"],
+      file: ["-e"],
+    });
+  });
+
+  test("ignores a trailing flag with no value", () => {
+    expect(collectRepeated(["tree", "-e"])).toEqual({ entry: [], file: [] });
+  });
+
+  test("is empty when neither flag appears", () => {
+    expect(collectRepeated(["tree", "src", "--locs"])).toEqual({
+      entry: [],
+      file: [],
+    });
+  });
+
+  test("normalizeArgv still returns argv unchanged but for lone --", () => {
+    expect(normalizeArgv(["tree", "-e", "a", "--", "src"])).toEqual([
+      "tree",
+      "-e",
+      "a",
+      "src",
+    ]);
+  });
+});
+
+const app = outdent`
+  export function boot(): void {
+    start();
+  }
+  export function createAgentSession(): void {
+    start();
+  }
+  function start(): void {}
+`;
+
+const other = outdent`
+  export function alpha(): void {}
+  export function beta(): void {}
+`;
+
+function entriesOf(stdout: string): string[] {
+  const parsed = JSON.parse(stdout) as {
+    data: { trees: Array<{ entry: string }> };
+  };
+  return parsed.data.trees.map((t) => t.entry);
+}
+
+describe("repeated --entry / --file", () => {
+  test("tree returns one tree per repeated --entry", () => {
+    const host = workspace({ "/src/app.ts": app });
+
+    const result = host.run(
+      "calldiff tree -e createAgentSession -e boot --format json --full-output -- src",
+    );
+
+    expect(result.code).toBe(0);
+    expect(entriesOf(result.stdout)).toEqual(["createAgentSession", "boot"]);
+  });
+
+  test("tree returns the union of every repeated --file", () => {
+    const host = workspace({ "/src/app.ts": app, "/src/other.ts": other });
+
+    const result = host.run(
+      "calldiff tree -F src/app.ts -F src/other.ts --format json --full-output -- src",
+    );
+
+    expect(result.code).toBe(0);
+    expect(entriesOf(result.stdout)).toEqual([
+      "boot",
+      "createAgentSession",
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  test("a single --entry is unchanged", () => {
+    const host = workspace({ "/src/app.ts": app });
+
+    const result = host.run(
+      "calldiff tree -e boot --format json --full-output -- src",
+    );
+
+    expect(result.code).toBe(0);
+    expect(entriesOf(result.stdout)).toEqual(["boot"]);
+  });
+
+  test("reach walks every repeated --entry", () => {
+    const host = workspace({ "/src/app.ts": app });
+
+    const result = host.run(
+      "calldiff reach -e createAgentSession -e boot --to start -- src",
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("createAgentSession()");
+    expect(result.stdout).toContain("boot()");
+  });
+
+  test("diff honours the README's two-entrypoint usage", () => {
+    const host = workspace();
+    const before = host.commit("before", {
+      "/src/app.ts": outdent`
+        export function boot(): void {}
+        export function createAgentSession(): void {}
+      `,
+    });
+    const after = host.commit("after", { "/src/app.ts": app });
+
+    const result = host.run(
+      `calldiff diff ${before} ${after} -e createAgentSession -e boot --format json --full-output -- src`,
+    );
+
+    expect(result.code).toBe(0);
+    expect(entriesOf(result.stdout)).toEqual(["createAgentSession", "boot"]);
+  });
+});

--- a/test/resolution-state.test.ts
+++ b/test/resolution-state.test.ts
@@ -1,0 +1,167 @@
+import { outdent } from "outdent";
+import { describe, expect, test } from "vitest";
+import { buildCallTree } from "../src/calltree.js";
+import { buildIndex, extractFunctions } from "../src/extract.js";
+import { findReachPaths } from "../src/reach.js";
+import { renderTree } from "../src/render.js";
+import type { CallNode } from "../src/types.js";
+import { workspace } from "./workspace.js";
+
+/**
+ * Three different facts used to serialize identically, so a consumer could not
+ * filter a tree to "calls into code in this repository": an unresolved callee,
+ * a resolved definition cut off by `--max-depth`, and a resolved definition
+ * that makes no calls. All three are childless leaves; only the resolver knew
+ * them apart, and it dropped what it knew.
+ */
+const source = `
+  export function entry(): void {
+    external();
+    empty();
+    hasBody();
+    recurse();
+  }
+
+  export function empty(): void {}
+
+  export function hasBody(): void {
+    empty();
+  }
+
+  export function recurse(): void {
+    entry();
+  }
+`;
+
+const index = buildIndex(extractFunctions("app.ts", source));
+
+function childOf(tree: CallNode, label: string): CallNode {
+  const found = tree.children.find((c) => c.label.startsWith(label));
+  if (!found) throw new Error(`no child ${label} in ${tree.label}`);
+  return found;
+}
+
+describe("resolution state on CallNode", () => {
+  test("an unresolved callee is marked, with no declaration", () => {
+    const node = childOf(buildCallTree("entry", index, 12), "external");
+    expect(node.resolved).toBe(false);
+    expect(node.declaredIn).toBeUndefined();
+    expect(node.truncated).toBeUndefined();
+    expect(node.children).toEqual([]);
+  });
+
+  test("a resolved definition carries where it is declared", () => {
+    const node = childOf(buildCallTree("entry", index, 12), "empty");
+    expect(node.resolved).toBe(true);
+    expect(node.declaredIn).toEqual({ file: "app.ts", line: 9 });
+  });
+
+  test("an empty body is not marked truncated", () => {
+    const node = childOf(buildCallTree("entry", index, 12), "empty");
+    expect(node.children).toEqual([]);
+    expect(node.truncated).toBeUndefined();
+  });
+
+  test("a body cut off by --max-depth is marked truncated", () => {
+    const node = childOf(buildCallTree("entry", index, 1), "hasBody");
+    expect(node.resolved).toBe(true);
+    expect(node.truncated).toBe(true);
+    expect(node.children).toEqual([]);
+  });
+
+  test("the depth cap does not mark an unresolved callee truncated", () => {
+    const node = childOf(buildCallTree("entry", index, 1), "external");
+    expect(node.resolved).toBe(false);
+    expect(node.truncated).toBeUndefined();
+  });
+
+  test("a cycle is a flag, not just a unicode suffix in the label", () => {
+    const node = childOf(
+      childOf(buildCallTree("entry", index, 12), "recurse"),
+      "entry",
+    );
+    expect(node.recursive).toBe(true);
+    // The suffix stays for ASCII readers.
+    expect(node.label).toBe("entry() ⇄");
+  });
+
+  test("branches carry no resolution state; they are not calls", () => {
+    const branchIndex = buildIndex(
+      extractFunctions(
+        "b.ts",
+        `
+          export function run(x: number): void {
+            if (x > 0) { work(); }
+          }
+          export function work(): void {}
+        `,
+      ),
+    );
+    const branch = buildCallTree("run", branchIndex, 12).children[0]!;
+    expect(branch.kind).toBe("branch");
+    expect(branch.resolved).toBeUndefined();
+    expect(branch.declaredIn).toBeUndefined();
+  });
+
+  test("reach paths keep the state through pathToTree", () => {
+    const [path] = findReachPaths("entry", "empty", index, 12);
+    expect(path).toBeDefined();
+    expect(path!.resolved).toBe(true);
+    expect(path!.declaredIn).toEqual({ file: "app.ts", line: 2 });
+    expect(path!.children[0]!.declaredIn).toEqual({ file: "app.ts", line: 9 });
+  });
+
+  test("ASCII rendering is untouched by the new fields", () => {
+    expect(renderTree(buildCallTree("entry", index, 12), { color: false })).toBe(
+      outdent`
+        entry()
+        ├─ external()
+        ├─ empty()
+        ├─ hasBody()
+        │  └─ empty()
+        └─ recurse()
+           └─ entry() ⇄
+      `,
+    );
+  });
+});
+
+describe("resolution state in --format json", () => {
+  test("survives serialization, and only on the nodes that have it", () => {
+    const host = workspace({
+      "/src/app.ts": outdent`
+        export function entry(): void {
+          external();
+          hasBody();
+        }
+        export function hasBody(): void {
+          leaf();
+        }
+        export function leaf(): void {}
+      `,
+    });
+
+    const result = host.run(
+      "calldiff tree -e entry --max-depth 1 --format json --full-output -- src",
+    );
+
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      data: { trees: Array<{ tree: CallNode }> };
+    };
+    const tree = parsed.data.trees[0]!.tree;
+
+    expect(tree.resolved).toBe(true);
+    expect(tree.declaredIn).toEqual({ file: "src/app.ts", line: 1 });
+
+    const external = tree.children.find((c) => c.key === "external")!;
+    expect(external.resolved).toBe(false);
+    expect(external).not.toHaveProperty("declaredIn");
+    expect(external).not.toHaveProperty("truncated");
+
+    const hasBody = tree.children.find((c) => c.key === "hasBody")!;
+    expect(hasBody.resolved).toBe(true);
+    expect(hasBody.declaredIn).toEqual({ file: "src/app.ts", line: 5 });
+    expect(hasBody.truncated).toBe(true);
+  });
+});

--- a/test/rust.test.ts
+++ b/test/rust.test.ts
@@ -38,6 +38,7 @@ test("rust: refactors calls into a helper with if/else", ({
     + │  ├─ auth_storage_create()
     + │  └─ create_coding_tools()
     + ├─ services.boot()
+      ├─ is_empty()
       ├─ if options.session_id.is_empty()
          └─ session_manager_create()
       └─ else

--- a/test/workspace.ts
+++ b/test/workspace.ts
@@ -28,8 +28,13 @@ export type WorkspaceHost = {
    *
    * Accepts either a full command string (`"calldiff reach -e foo --to bar"`)
    * or argv without the binary (`"reach -e foo --to bar"` / `["reach", ...]`).
+   * `env` overrides variables for that one run, e.g. a scratch
+   * `CALLDIFF_GRAMMAR_CACHE`.
    */
-  run: (command: string | string[]) => RunResult;
+  run: (
+    command: string | string[],
+    options?: { env?: Record<string, string> },
+  ) => RunResult;
   /** Write (or overwrite) files relative to the workspace root. */
   write: (files: Record<string, string>) => void;
   /**
@@ -86,7 +91,7 @@ export function workspace(files: Record<string, string> = {}): WorkspaceHost {
       git(root, ["commit", "-qm", name]);
       return git(root, ["rev-parse", "HEAD"]).trim();
     },
-    run(command) {
+    run(command, options) {
       const args = normalizeArgv(command);
       const result = spawnSync(
         process.execPath,
@@ -98,6 +103,7 @@ export function workspace(files: Record<string, string> = {}): WorkspaceHost {
             ...process.env,
             // Keep grammar cache shared with the vitest env.
             FORCE_COLOR: "0",
+            ...options?.env,
           },
         },
       );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,10 @@ export default defineConfig({
     env: {
       CALLDIFF_GRAMMAR_CACHE: join(tmpdir(), "calldiff-grammar-cache"),
     },
+    // On a cold cache the first test per language installs and natively builds
+    // a grammar, and those installs serialize on the cache lock, so a worker
+    // can legitimately wait several minutes. Matches the lock's own timeout.
+    // Warm runs are unaffected: the whole suite takes a few seconds.
+    testTimeout: 15 * 60_000,
   },
 });


### PR DESCRIPTION
## Summary

Four fixes on calldiff's machine-facing surface — the `reach` graph, repeated `--entry`/`--file`, the structured `CallNode`, and the on-demand grammar install — plus two grammar-cache bugs found while verifying the fourth, none of which change what a human reads in an ASCII tree.

## The four issues

1. **A call in an `if` / `else if` test, or a `switch` / `match` subject, was never an edge.** It went into the branch node's label — or nowhere at all — so `tree` printed `guard` while `reach` said `No paths` and exited 0.
2. **Repeated `--entry` / `--file` kept only the last value.** `-e a -e b` silently dropped `a`, which breaks a usage line printed in this README and contradicts the schema the tool publishes for both flags.
3. **`CallNode` discarded resolution state the resolver had already computed.** An unresolved callee, a definition truncated by `--max-depth`, and a definition with an empty body all serialized as the same childless leaf.
4. **There was no way to decline the on-demand grammar install.** `CALLDIFF_GRAMMAR_CACHE` could move where several MB of npm install and native build landed, never whether they happened.

## Why this fits calldiff

The README's first line is *"Built for **agentic code review**"*, and the Output section promises a *"structured result … for agents and scripts."* The premise is that a program is the consumer, and the surface built for that program is unusually complete: an MCP server, skill files, `--llms`, `--format json|yaml|md|jsonl`, and token budgeting. All four issues sit on exactly that surface. ASCII output is byte-identical apart from issue 1, where the new edge is the fix.

Issues 1 and 2 restore documented guarantees rather than adding behaviour. `### reach` promises every call path *"including alternate `if` / `else` arms"*; the Usage section prints `calldiff diff main feature -e PiService.createAgentSession -e boot` as the way to pass two entrypoints, and it returned only `boot`.

Issue 3 completes the structured-output contract in the same spirit as `key`, which is already there *"for matching across versions"* — surfacing state `expandCall` computes and drops, so a consumer stops inferring it from label text. `src/types.ts` documented the resulting ambiguity in its own comment; that comment is now a set of fields.

Issue 4 extends the existing `CALLDIFF_GRAMMAR_CACHE` seam with the one lever it lacked, and preserves the per-file degradation behaviour exactly: an unparseable file is skipped with one warning on stderr, stdout stays clean, and a mixed repository still answers for every language it can parse.

## Reproduction

Every command below was run against **`b64e3b9`** (`main` at the time of writing — the original report was written against `8580389`, six commits earlier; all four still reproduce). Where a repro reads this repo's own source, it is pinned with an explicit ref so the before and after runs analyse identical input.

### Issue 1

```bash
REPRO=$(mktemp -d) && cd "$REPRO" && git init -q
cat > a.ts <<'EOF'
export function guard(x: number): boolean { return x > 0; }
export function target(): number { return 42; }

export function viaIf(x: number): number {
  if (guard(x)) { return target(); }
  return 0;
}
export function viaWhile(x: number): number {
  while (guard(x)) { x--; }
  return target();
}
EOF
git add -A && git -c user.email=t@t -c user.name=t commit -qm init
```

```
$ <checkout>/node_modules/.bin/tsx <checkout>/src/cli.ts tree a.ts --entry viaIf --locs
viaIf(x)  a.ts:4
└─ if (guard(x))  a.ts:5
   └─ target()  a.ts:5

$ ... reach a.ts --entry viaIf --to guard
No paths from viaIf to guard.
```

`while`, which is not modelled as a branch, isolates the cause — its condition call is an ordinary edge:

```
$ ... tree a.ts --entry viaWhile --locs
viaWhile(x)  a.ts:8
├─ guard(x)  a.ts:9
└─ target()  a.ts:10
```

Not TypeScript-specific. The same file in Python, with the Python grammar:

```
$ ... tree a.py --entry via_if --locs
via_if(x)  a.py:7
└─ if guard(x)  a.py:8
   └─ target()  a.py:9

$ ... reach a.py --entry via_if --to guard
No paths from via_if to guard.
```

A `switch` / `match` subject is the same defect, and leaves even less behind — the call reaches neither the graph nor a label:

```
$ ... tree a.js --entry viaSwitch          $ ... tree a.py --entry via_match
viaSwitch(x)                               via_match(x)
├─ case "a"                                └─ case "a"
   └─ target()                                └─ target()
└─ default

$ ... reach a.js --entry viaSwitch --to getKind
No paths from viaSwitch to getKind.
```

TypeScript is the control: it never special-cased `switch`, so the same source already produced `├─ getKind(x)` as an ordinary edge there.

### Issue 2

```
$ npm run --silent dev -- tree --schema | grep -A6 'entry:'
    entry:
      anyOf[2]:
        - type: string
        - type: array
          items:
            type: string
      description: "Entrypoint symbol(s): functionName or ClassName.method"

$ ... tree b64e3b9 -e loadGrammarPackage -e grammarCacheDir \
    --max-depth 0 --format json --full-output -- src | jq -c '[.data.trees[].entry]'
["grammarCacheDir"]

$ ... tree b64e3b9 -F src/languages/grammars.ts -F src/git.ts \
    --max-depth 0 --format json --full-output -- src | jq -c '[.data.trees[].entry]'
["assertGitRepo","describeSnapshot","listSnapshotFiles","listSourceFiles","listTsFiles",
 "readSnapshotFiles","resolveDiffSnapshotsAndPaths","resolveSnapshot","resolveSnapshotAndPaths",
 "resolveSnapshots","verifyCommit","visitCommitBlobs","visitWorktreeFiles"]
```

`loadGrammarPackage` and all of `grammars.ts` are discarded without a word.

### Issue 3

```
$ ... tree b64e3b9 --entry loadGrammarPackage --max-depth 1 --format json --full-output -- src \
  | jq -c '.data.trees[0].tree.children[]
           | select(.label|test("createRequire|grammarCacheDir|requireGrammar"))
           | {label,kind,file,line,children:(.children|length)}'
{"label":"createRequire()","kind":"call","file":"src/languages/grammars.ts","line":107,"children":0}
{"label":"grammarCacheDir()","kind":"call","file":"src/languages/grammars.ts","line":128,"children":0}
{"label":"createRequire()","kind":"call","file":"src/languages/grammars.ts","line":151,"children":0}
{"label":"requireGrammar(require, npmPackage, packageRoot)","kind":"call","file":"src/languages/grammars.ts","line":153,"children":0}
```

Three different facts, one shape: `createRequire` is a Node builtin with genuinely nothing beneath it; `grammarCacheDir` is declared in this repo and makes three calls; `requireGrammar` is resolved and cut off by the depth cap. Empty parens do not disambiguate — `grammarCacheDir` is zero-arity, so a resolved project function renders exactly like a builtin. Raising the depth proves they differ and that only calldiff knew:

```
$ ... --max-depth 2 ... | jq -c '... | {label,kids:(.children|length)}'
{"label":"createRequire()","kids":0}
{"label":"grammarCacheDir()","kids":3}
{"label":"createRequire()","kids":0}
```

### Issue 4

```bash
REPRO=$(mktemp -d) && CACHE=$(mktemp -d)/fresh
cd "$REPRO" && git init -q
printf 'def sink(x):\n    print(x)\n\ndef main():\n    sink(1)\n' > a.py
git add -A && git -c user.email=t@t -c user.name=t commit -qm init
```

```
$ ls "$CACHE/node_modules"; CALLDIFF_GRAMMAR_CACHE="$CACHE" ... tree --entry main
(cache does not exist)

calldiff tree working tree

main()
└─ sink(x)
   └─ print()

$ ls "$CACHE/node_modules"; du -sh "$CACHE"
node-addon-api   node-gyp-build   tree-sitter-python
7.7M
```

The tree is correct; the side effect is 7.7 MB downloaded and natively built during what the caller asked to be a read. The only opt-out was an uncreatable cache path, which stops the install and then misreports the cause:

```
$ CALLDIFF_GRAMMAR_CACHE=/nonexistent-xyz ... tree --entry main
warn: failed to parse a.py @ WORKTREE: ENOENT: no such file or directory, mkdir '/nonexistent-xyz'
```

### The grammar cache

Two things both found while checking that `--offline` had something to be offline *from*.

It does not accumulate. `ensureCachePackageJson` writes a `package.json` with no `dependencies` and the install passes `--no-save`, so npm reconciles the tree against that empty file and removes what is already there:

```
$ ls $CACHE/node_modules
node-addon-api   node-gyp-build   tree-sitter-python
$ ... tree --entry main          # a Ruby repo, same cache
added 1 package, and removed 1 package
$ ls $CACHE/node_modules
node-addon-api   node-gyp-build   tree-sitter-ruby
```

Python is gone. The cache only ever holds the most recently used language, so a polyglot repository re-downloads and rebuilds on every run.

And it does not tolerate concurrency. npm is not safe against one `--prefix` from several processes at once, so two calldiff invocations installing into a shared cache collide. Deleting the test cache and running `npm test` — which is `vitest run`, with file parallelism — is enough to show it:

```
$ rm -rf $CACHE && npm test
 Test Files  21 failed | 17 passed (38)
      Tests  126 failed | 173 passed (299)

$ npm test 2>&1 | grep -oE 'ENOTEMPTY|Cannot find module' | sort | uniq -c
  94 ENOTEMPTY
  40 no such file or directory, lstat '.../tree-sitter-ocaml/grammars'
```

The cache is left corrupt, so subsequent runs keep failing until it is deleted. A consumer fanning calldiff out across a repository — several processes, one `~/.cache/calldiff/grammars` — hits exactly this.

## Changes by issue

**Issue 1** — `f34bf1c`, 25 files. Each extractor now walks the branch test for calls and emits them as steps immediately *before* the branch, because the test runs before the arm — the shape `while (guard(x))` already produced by taking the ordinary path. Applied at the `if` and `else if` sites of all 21 extractors that build branch steps; the several that model `else if` by re-collecting the nested `if` and relabelling (`java.ts`, `ocaml.ts`, `solidity.ts`, `zig.ts`, and the `pushIfChain` recursions in `go.ts`, `kotlin.ts`, `rust.ts`, `scala.ts`, `swift.ts`) inherit it from the single `if` site. Written into `src/languages/CONTRACT.md` "Must support" #4 so a new extractor inherits the rule.

Three notes. `elixir.ts` already walked its condition, after the branch push — that moved earlier for consistent ordering, and is the precedent that this is completion rather than addition. `go.ts` also walks the init statement in `if v, err := doThing(); err != nil`, which reached neither the label nor the graph. `haskell.ts` needed a qualification: a bare `variable` counts there as a nullary call, so walking `if x == 1` would report a call to the parameter `x`; `collectExpr` takes a `nullaryVariables` flag, false when walking a test, and applications inside a test are still collected either way.

Deliberately unchanged: the branch label still renders the full condition; `while`, ternary, `&&`, assign-then-test and `return` were already correct and were re-checked.

**Issue 1, continued** — `e5ef568`, 15 files. The same defect one node over: a `switch` / `match` subject runs before any arm is chosen, and every extractor that special-cases `switch` iterated its clauses and returned without walking it. Worse than the `if` case — the subject did not even reach a label, so the call left no trace at all. TypeScript is the accidental control here: it never special-cased `switch`, so its subject took the ordinary path and was always an edge; this makes the others agree with the one that was already right. Covers `switch`, `match`, `when` and bash `case` across bash, c, csharp, go, java, javascript, kotlin, ocaml, python, rust, scala, swift and zig. The arms stay branch nodes; only the subject is added, once, before them. Separate commit so each half is revertable on its own.

**Issue 2** — `a5f707f`, `src/cli.ts`. `normalizeArgv` — already this file's argv funnel, and already where `--token-count` is detected for the same reason — records repeated `--entry`/`--file` values via a new exported `collectRepeated`, and `entriesFromOption` prefers them. One left-to-right pass, so a value spelled like a flag (`--file -e`) is not read as one. `--flag value`, `--flag=value` and `-f value` are handled; `-f=value` is not, because incur does not accept it either. The option schemas are untouched, so MCP and HTTP callers keep both shapes and keep going through the parsed option, where no collected values exist.

**Issue 3** — `6e4db4e`, `src/types.ts`, `src/calltree.ts`, `src/run.ts`, `src/reach.ts`. `expandCall` already had `info` and dropped it at three returns that differ in meaning but not in shape (`depth >= maxDepth`, `!info`, and the fully-expanded return). It now carries `resolved`, `declaredIn`, `truncated` and `recursive` onto call nodes. `truncated` is set only when the cap actually cut something off, so an unresolved callee at the depth limit is not marked. Branch nodes carry none of it — a branch is not a call, and `kind` already says so. `file`/`line` keep meaning the call site. Carried through both places that rebuild nodes field by field: `serializeCallNode` and reach's `pathToTree`.

**Issue 4** — `85f52ea`, `src/languages/grammars.ts`, `src/extract.ts`, `src/run.ts`, `src/cli.ts`, `README.md`. Adds `--offline` on all three commands, `CALLDIFF_OFFLINE=1`, and `offline` on the three `run*` option types. The flag is `z.boolean().optional()` rather than defaulted, so an unset flag falls through to the environment instead of overriding it. `loadGrammarPackage` takes the language id so the message names `python`, not just the package. The non-offline failure path is honest too: a failed install reports which grammar and which cache, and `ensureCachePackageJson` moved inside the `try` because creating the directory is the step that actually fails on an unwritable path. README now records which grammars are bundled — `tree-sitter-typescript` and `tree-sitter-javascript`, so TS/TSX/JS/JSX need nothing — and that the other 18 are fetched on first use.

**The cache, part one** — `41aac3a`, `src/languages/grammars.ts`. `grammarInstallArgs` records the install (`--save-exact`) instead of `--no-save`, so the cache accumulates, which is what the README already calls it, and is what makes `--offline` usable: you cannot pre-populate a cache that deletes itself. Exact versions so installing one grammar cannot drift another, including the two `INSTALL_SPEC` pins.

**The cache, part two** — `src/languages/grammars.ts`, `vitest.config.ts`. `withInstallLock` holds an exclusive lock on the cache directory across the install, so processes sharing a cache queue instead of colliding. `mkdir` is atomic and fails `EEXIST` when the directory exists, which is the portable way to take a lock without adding a dependency; a lock left by a killed process is reclaimed once stale, so a crash costs a wait rather than a permanently wedged cache. Under the lock the install re-checks whether the grammar arrived while it was waiting, so N processes racing for one grammar perform one install, not N. `vitest.config.ts` raises `testTimeout` to match the lock timeout, because on a cold cache the first test for a language legitimately waits on serialized native builds; warm runs still finish in seconds.

Neither of these two was asked for. They are last, they are separate commits, and they can be dropped independently — though dropping the second means `npm test` cannot pass from a clean checkout.

## New outcome

### Issue 1

```
$ ... tree a.ts --entry viaIf --locs
viaIf(x)  a.ts:4
├─ guard(x)  a.ts:5
└─ if (guard(x))  a.ts:5
   └─ target()  a.ts:5

$ ... reach a.ts --entry viaIf --to guard
viaIf(x)
└─ guard(x)

$ ... tree a.ts --entry viaWhile --locs          # unchanged
viaWhile(x)  a.ts:8
├─ guard(x)  a.ts:9
└─ target()  a.ts:10
```

`viaIf` now has exactly the shape `viaWhile` always had. Python agrees:

```
$ ... tree a.py --entry via_if --locs
via_if(x)  a.py:7
├─ guard(x)  a.py:8
└─ if guard(x)  a.py:8
   └─ target()  a.py:9
```

And the subject of a `switch` / `match`, which now matches what TypeScript always did:

```
$ ... tree a.js --entry viaSwitch          $ ... tree a.py --entry via_match
viaSwitch(x)                               via_match(x)
├─ getKind(x)                              ├─ get_kind(x)
├─ case "a"                                └─ case "a"
   └─ target()                                └─ target()
└─ default

$ ... reach a.js --entry viaSwitch --to getKind
viaSwitch(x)
└─ getKind(x)
```

Every form in the original scope table, re-measured as `reach` path counts against one fixture:

| form | before | after |
|---|---|---|
| `if (guard(x))` | No paths | **1 path** |
| `else if (g1(x))` | No paths | **1 path** |
| `while (guard(x))` | 1 path | 1 path |
| `guard(x) ? target() : 0` | 1 path | 1 path |
| `guard(x) && target()` | 1 path | 1 path |
| `const ok = guard(x); if (ok)` | 1 path | 1 path |
| `return guard(x)` | 1 path | 1 path |

### Issue 2

```
$ ... tree b64e3b9 -e loadGrammarPackage -e grammarCacheDir \
    --max-depth 0 --format json --full-output -- src | jq -c '[.data.trees[].entry]'
["loadGrammarPackage","grammarCacheDir"]

$ ... tree b64e3b9 -F src/languages/grammars.ts -F src/git.ts \
    --max-depth 0 --format json --full-output -- src | jq -c '[.data.trees[].entry]'
["grammarCacheDir","loadGrammarPackage","readCachedPackageVersion","resolveLanguage",
 "assertGitRepo","describeSnapshot","listSnapshotFiles","listSourceFiles","listTsFiles",
 "readSnapshotFiles","resolveDiffSnapshotsAndPaths","resolveSnapshot","resolveSnapshotAndPaths",
 "resolveSnapshots","verifyCommit","visitCommitBlobs","visitWorktreeFiles"]
```

The union of both files, and the published schema is unchanged. The comma-separated form is still read as one symbol name, which is correct — it was never a documented spelling:

```
$ ... tree b64e3b9 --entry "loadGrammarPackage,grammarCacheDir" -- src
message: "Entrypoint not found: loadGrammarPackage,grammarCacheDir"
```

### Issue 3

```
$ ... tree b64e3b9 --entry loadGrammarPackage --max-depth 1 --format json --full-output -- src \
  | jq -c '... | {label,resolved,declaredIn,truncated,children:(.children|length)}'
{"label":"createRequire()","resolved":false,"declaredIn":null,"truncated":null,"children":0}
{"label":"grammarCacheDir()","resolved":true,"declaredIn":{"file":"src/languages/grammars.ts","line":20},"truncated":true,"children":0}
{"label":"createRequire()","resolved":false,"declaredIn":null,"truncated":null,"children":0}
{"label":"requireGrammar(require, npmPackage, packageRoot)","resolved":true,"declaredIn":{"file":"src/languages/grammars.ts","line":71},"truncated":true,"children":0}
```

(`null` is `jq` printing an absent key.) The three cases are now distinct in one pass: unresolved with no declaration; resolved, declared at `grammars.ts:20`, body withheld by the cap; resolved, declared at `grammars.ts:71`, body withheld by the cap. A cycle carries `recursive: true` alongside the `⇄` suffix it already had.

### Issue 4

```
$ ls "$CACHE/node_modules"; CALLDIFF_GRAMMAR_CACHE="$CACHE" ... tree --entry main --offline
(cache does not exist)
warn: failed to parse a.py @ WORKTREE: no grammar for python available offline:
  tree-sitter-python is not bundled and not in <cache>.
  Install it there, or drop --offline / CALLDIFF_OFFLINE to fetch it on demand.

$ ls "$CACHE"
(cache still does not exist)
```

Nothing installed, and the warning names the grammar and the way out. Without the flag, against its own fresh cache, behaviour is exactly as before — same tree, same 7.7 MB:

```
$ CALLDIFF_GRAMMAR_CACHE="$OTHER" ... tree --entry main
main()
└─ sink(x)
   └─ print()
$ ls "$OTHER/node_modules"; du -sh "$OTHER"
node-addon-api   node-gyp-build   tree-sitter-python
7.7M
```

Per-file degradation is intact — in a repo holding both `a.py` and `b.ts`, with `--offline` and an empty cache, the Python file is skipped with exactly one warning on stderr and TypeScript still answers on stdout, exit 0:

```
$ ... tree --entry boot --offline
warn: failed to parse a.py @ WORKTREE: no grammar for python available offline: ...
calldiff tree working tree

boot()
└─ helper()
```

And the install failure now names its cause:

```
$ CALLDIFF_GRAMMAR_CACHE=/nonexistent-xyz ... tree --entry main
warn: failed to parse a.py @ WORKTREE: failed to install grammar for python
  (tree-sitter-python) into /nonexistent-xyz: ENOENT: no such file or directory, mkdir '/nonexistent-xyz'
```

### The grammar cache

Python then Ruby into one cache, where before the second install deleted the first:

```
$ ls $CACHE/node_modules      # after the Python repo
node-addon-api  node-gyp-build  tree-sitter-python
$ ls $CACHE/node_modules      # after the Ruby repo, same cache
node-addon-api  node-gyp-build  tree-sitter-python  tree-sitter-ruby
$ cat $CACHE/package.json
{"name":"calldiff-grammar-cache","private":true,"description":"On-demand tree-sitter grammars for calldiff",
 "dependencies":{"tree-sitter-python":"0.25.0","tree-sitter-ruby":"0.23.1"}}
```

A third run over the Python repo installs nothing and finishes in 0.27s.

And concurrent installs queue instead of colliding. The same check as before — delete the cache, run the parallel suite — on the same machine that produced the 21-failure run above:

```
$ rm -rf $CACHE && npm test
 Test Files  38 passed (38)
      Tests  303 passed (303)
   Duration  171.92s
$ ls $CACHE/node_modules | wc -l
      25
$ ls -a $CACHE | grep install-lock
(none)
```

Two consecutive cold runs from an empty cache, both green. The run leaves a complete cache and no lock behind, where before it left a broken one that kept failing until deleted by hand.

## Testing

`npm run build` (tsc, strict) and `npm test` both pass: **38 files, 306 tests**, up from 34 and 255.

- **Issue 1** — `test/branch-conditions.test.ts` (15 tests): `reach` finds the callee through an `if` and an `else if`; the five forms that already worked are asserted unchanged; the emitted edge is a sibling of the branch and matches `while`'s shape exactly; the branch label still shows the condition; a test with no calls adds no steps; an end-to-end `reach` through the CLI; and Python, so the fix is not asserted only in the language it was reported in. Three more cover the switch/match subject in TypeScript, JavaScript and Python, including an assertion that the arms stay branch nodes rather than being flattened. The `haskell` and `rust` fixtures gained the calls their `if` conditions always made — `null()`/`sessionId(_)` and `is_empty()`. Every other language fixture is unchanged, which is the evidence that existing branch rendering is untouched.
- **Issue 2** — `test/repeated-options.test.ts` (11 tests): `collectRepeated` over both spellings, the `=` form, a value spelled like a flag, a trailing flag with no value; then end-to-end, one tree per repeated `-e`, the union of repeated `-F`, an unchanged single `-e`, `reach` over several entries, and the README's two-entrypoint `diff` line.
- **Issue 3** — `test/resolution-state.test.ts` (10 tests): each of the three leaf cases; an unresolved callee at the depth cap is *not* marked truncated; recursion sets the flag and keeps the `⇄` suffix; branches carry no resolution state; `reach` paths keep it through `pathToTree`; ASCII output asserted verbatim; and the whole shape re-checked after JSON serialization.
- **Issue 4 and the two cache bugs** — `test/offline.test.ts` (15 tests): the env/flag precedence table; `--offline` and `CALLDIFF_OFFLINE` each install nothing, asserted by the scratch cache directory never being created; the mixed-language run degrades to exactly one stderr warning with a clean stdout; bundled grammars are byte-identical with and without the flag; the install failure names the grammar; `grammarInstallArgs` records the install rather than pruning; and `withInstallLock` runs and releases, releases when the install throws, times out with an actionable message while another process holds it, and reclaims a lock left behind by a dead process. `test/workspace.ts` gained a per-run `env` override so a test can point at a scratch cache.

Beyond the suite, ASCII output was compared mechanically for issue 3: **13,054 lines** of `tree` (with and without `--locs`, at two depths, over seven entrypoints), `reach` and `diff` output over this repo compare byte-identical before and after that commit.

The suite also now passes from a genuinely clean state. Before this branch, `rm -rf $CALLDIFF_GRAMMAR_CACHE && npm test` failed 126 of 299 tests and left the cache corrupt for every later run; it now passes 303/303 in one go, at the cost of several minutes of first-run native builds.

## Compatibility

Additive. No existing field changes meaning or moves.

- `CallNode` gains four optional fields (`resolved`, `declaredIn`, `truncated`, `recursive`). `file`/`line`/`endLine` keep meaning the call site; the *declaration* site is the new `declaredIn`. Consumers that read `resolved` should check `kind !== "branch"` first — branches carry no resolution state, by design. `DiffNode` is untouched, so `diff` JSON is unchanged.
- The `--entry` / `--file` schemas are unchanged, so MCP and HTTP callers keep both the string and array shapes. Single-value CLI usage is unchanged. The only behaviour change is that a repeated flag now accumulates instead of discarding, which no caller could have been relying on.
- `--offline` and `CALLDIFF_OFFLINE` are new and default off; without them the install path behaves exactly as before.
- Issue 1 adds a node to ASCII and JSON trees wherever a branch test contains a call — the fix itself, and the only intended output change in this PR. A consumer that counts children of a node containing such an `if` will see one more; `diff` will show it as added when comparing an old tree to a new one.
- Two things a downstream consumer should know about the grammar cache. `--save-exact` writes `dependencies` and a lockfile into it, and an install now briefly creates a `.install-lock` directory there. Existing caches are unaffected and keep working; the first install after upgrading starts recording. Anything that enumerates `node_modules` in the cache is unaffected, but anything that enumerates the cache root will see the lock while an install is in flight.
