### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Typecheck (build)
+        run: npm run build
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
# ci: add GitHub Actions workflow

补了个 CI：push main / PR 触发，Node 22 + 24 矩阵，`npm ci` → `tsc` build → `vitest run`。

这仓库 30+ commits、一堆外部 PR（#30/#33 那些），没有任何自动化保护——万一谁把 tsc 或测试弄挂了就悄悄上线了。加个 CI 至少兜个底。

已在本机跑通同一套命令：`npm ci` + `npm run build`（tsc） + `npm test`（34 files / 255 tests 全绿）。

（顺手说一句：`test` 脚本里的 `vitest run` 在 CI 里没问题，但如果想更快可以后续加 vitest 的 `--pool=forks`，不在这 PR 里动。）
