### PR TITLE
ci: run tests on PRs after owner approval

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+# Runs npm test on a PR only after the repo owner submits an Approve review.
+# New commits after that do not re-run until you approve again.
+#
+# GitHub does not let you approve your own PR. For those, use
+# Actions → Test → Run workflow (optionally pass a PR number).
+name: Test
+
+on:
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to test (empty = the selected branch)
+        required: false
+
+concurrency:
+  group: test-${{ github.event.inputs.pr || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    name: npm test
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.review.state == 'approved' &&
+        github.event.review.user.login == github.repository_owner &&
+        github.event.pull_request.state == 'open'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Resolve checkout ref
+        id: checkout
+        env:
+          PR: ${{ github.event.inputs.pr || github.event.pull_request.number }}
+        run: |
+          if [ -n "$PR" ]; then
+            echo "ref=refs/pull/${PR}/head" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout.outputs.ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/cache@v4
+        with:
+          path: /tmp/calldiff-grammar-cache
+          key: grammars-${{ runner.os }}-${{ hashFiles('package-lock.json', 'src/languages/grammars.ts') }}
+          restore-keys: |
+            grammars-${{ runner.os }}-
+
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `Test` GitHub Actions workflow that runs `npm ci`, `npm run build`, and `npm test` on pull requests, but **not** on every push.

It runs when:

- The **repo owner** submits an **Approve** review on an open PR
- Anyone with write access uses **Actions → Test → Run workflow** (`workflow_dispatch`), optionally with a PR number

GitHub does not allow self-approval, so your own PRs need the manual dispatch. New commits after an approval do not re-run until you approve again (or dispatch).

Grammar packages are cached under `/tmp/calldiff-grammar-cache` between runs.

## Test plan

- [x] Workflow YAML parses
- [x] `actionlint` reports no findings
- [ ] After merge: Approve a collaborator PR and confirm `Test / npm test` runs
- [ ] After merge: `workflow_dispatch` on a branch / PR number

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e19e8360-6713-4c7c-a9a4-bbea2a3e8088?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e19e8360-6713-4c7c-a9a4-bbea2a3e8088&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

