### PR TITLE
Apply anti-slop lint fixes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,11 +8,17 @@ import type { DiffResult, ReachResult, TreeResult } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+type PackageJson = {
+  version?: string;
+};
+
 function readVersion(): string {
   try {
-    const pkg = JSON.parse(
+    const raw: unknown = JSON.parse(
       readFileSync(join(__dirname, "..", "package.json"), "utf8"),
-    ) as { version?: string };
+    );
+    // SAFETY: package.json is authored by this repo; only version is read.
+    const pkg = raw as PackageJson;
     return pkg.version ?? "0.0.0";
   } catch {
     return "0.0.0";
@@ -54,21 +60,32 @@ function entriesFromOption(
   return Array.isArray(entry) ? entry : [entry];
 }
 
+type CtaCommandOptions = {
+  entry?: string;
+  file?: string;
+  to?: string;
+};
+
 type CtaMeta = {
   cta: {
     commands: Array<{
       command: string;
       description?: string;
-      options?: Record<string, unknown>;
+      options?: CtaCommandOptions;
     }>;
   };
 };
 
+/** Empty payload when ASCII was already written to stdout and only a CTA remains. */
+type AsciiCtaPayload = Record<string, never>;
+
 type EmitContext = {
   agent: boolean;
   formatExplicit: boolean;
-  ok: (data: unknown, meta?: CtaMeta) => never;
+  ok: (data: AsciiCtaPayload, meta?: CtaMeta) => never;
 };
+
+type CommandResult = DiffResult | TreeResult | ReachResult;
 
 /**
  * Default: classic ASCII (TTY + pipes) with optional CTAs.
@@ -83,9 +100,9 @@ type EmitContext = {
  */
 function emitAsciiOrData(
   c: EmitContext,
-  result: DiffResult | TreeResult | ReachResult,
+  result: CommandResult,
   cta?: CtaMeta,
-): unknown {
+): CommandResult | string | undefined {
   if (!c.formatExplicit) {
     if (tokenFlagActive) return result.ascii;
     process.stdout.write(

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -5,18 +5,25 @@
 import { createHash } from "node:crypto";
 import Parser from "tree-sitter";
 import type { CallStep, FunctionInfo } from "./types.js";
-import { loadGrammarPackage, resolveLanguage } from "./languages/grammars.js";
+import {
+  loadGrammarPackage,
+  resolveLanguage,
+  type GrammarLanguage,
+} from "./languages/grammars.js";
 import { detectLanguage } from "./languages/registry.js";
 import { linesFromOffsets } from "./loc.js";
 
 const parser = new Parser();
-const languageCache = new Map<string, unknown>();
+const languageCache = new Map<string, GrammarLanguage>();
 
 function grammarKey(npmPackage: string, grammarExport?: string): string {
   return grammarExport ? `${npmPackage}:${grammarExport}` : npmPackage;
 }
 
-function loadLanguage(npmPackage: string, grammarExport?: string): unknown {
+function loadLanguage(
+  npmPackage: string,
+  grammarExport?: string,
+): GrammarLanguage {
   const key = grammarKey(npmPackage, grammarExport);
   const cached = languageCache.get(key);
   if (cached) return cached;
@@ -38,7 +45,10 @@ export function extractFunctions(
     extractor.grammarPackage,
     extractor.grammarExport,
   );
-  parser.setLanguage(language as any);
+  // Grammar package exports are accepted by setLanguage at runtime; the
+  // published Language type requires fields not present on every package.
+  // @ts-expect-error tree-sitter Language under-specifies grammar module exports
+  parser.setLanguage(language);
   const tree = parser.parse(source);
   return extractor.extract(file, source, tree).map((fn) => {
     if (fn.line != null) return fn;
@@ -64,7 +74,7 @@ export function extractCached(
 
   if (!functions) {
     functions = extractFunctions(file, source).map(
-      ({ file: ignored, ...fn }) => fn,
+      ({ file: _ignored, ...fn }) => fn,
     );
     cache.set(key, functions);
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,7 +2,12 @@ import { execFileSync } from "node:child_process";
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { listSupportedExtensions } from "./languages/registry.js";
-import type { Snapshot } from "./types.js";
+import type {
+  Snapshot,
+  SnapshotPair,
+  SnapshotPairWithPaths,
+  SnapshotWithPaths,
+} from "./types.js";
 
 function gitBuffer(
   cwd: string,
@@ -33,7 +38,7 @@ export function assertGitRepo(cwd: string): void {
 export function resolveSnapshots(
   from: string | undefined,
   to: string | undefined,
-): { from: Snapshot; to: Snapshot } {
+): SnapshotPair {
   // git-diff defaults: no args → HEAD vs worktree; one arg → that vs worktree
   const left: Snapshot = {
     kind: "commit",
@@ -73,7 +78,7 @@ export function resolveDiffSnapshotsAndPaths(
   from: string | undefined,
   to: string | undefined,
   paths: string[],
-): { from: Snapshot; to: Snapshot; paths: string[] } {
+): SnapshotPairWithPaths {
   if (from === undefined && to === undefined) {
     return { ...resolveSnapshots(undefined, undefined), paths };
   }
@@ -125,7 +130,7 @@ export function resolveSnapshotAndPaths(
   cwd: string,
   ref: string | undefined,
   paths: string[],
-): { snapshot: Snapshot; paths: string[] } {
+): SnapshotWithPaths {
   if (ref === undefined) {
     return { snapshot: resolveSnapshot(undefined), paths };
   }

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -9,9 +9,13 @@ import {
   resolveEntrypointFile,
 } from "./calltree.js";
 import { diffTrees, treeHasChanges } from "./diff.js";
-import type { DiffNode, FunctionInfo } from "./types.js";
+import type { CallNode, DiffNode, FunctionInfo } from "./types.js";
 
-function functionShape(fn: FunctionInfo | undefined): string | null {
+function emptyCallTree(key: string, label: string): CallNode {
+  return { key, label, children: [] };
+}
+
+function functionFingerprint(fn: FunctionInfo | undefined): string | null {
   if (!fn) return null;
   return JSON.stringify({ label: fn.label, steps: fn.steps });
 }
@@ -46,7 +50,7 @@ function findAffected(
   const queue: string[] = [];
 
   for (const key of keys) {
-    if (functionShape(before.get(key)) === functionShape(after.get(key))) {
+    if (functionFingerprint(before.get(key)) === functionFingerprint(after.get(key))) {
       continue;
     }
     distance.set(key, 0);
@@ -192,19 +196,11 @@ export function diffEntry(
 
   const beforeTree = hasBefore
     ? buildCallTree(beforeKey, before, maxDepth)
-    : {
-        key: afterKey,
-        label: after.get(afterKey)?.label ?? afterKey,
-        children: [] as [],
-      };
+    : emptyCallTree(afterKey, after.get(afterKey)?.label ?? afterKey);
 
   const afterTree = hasAfter
     ? buildCallTree(afterKey, after, maxDepth)
-    : {
-        key: beforeKey,
-        label: before.get(beforeKey)?.label ?? beforeKey,
-        children: [] as [],
-      };
+    : emptyCallTree(beforeKey, before.get(beforeKey)?.label ?? beforeKey);
 
   if (!hasBefore && hasAfter) {
     const diff = diffTrees(
@@ -241,19 +237,11 @@ export function diffPinnedEntry(
 
   const beforeTree = beforeInfo
     ? buildCallTreeFromInfo(beforeInfo, before, maxDepth)
-    : {
-        key,
-        label: afterInfo?.label ?? key,
-        children: [] as [],
-      };
+    : emptyCallTree(key, afterInfo?.label ?? key);
 
   const afterTree = afterInfo
     ? buildCallTreeFromInfo(afterInfo, after, maxDepth)
-    : {
-        key,
-        label: beforeInfo?.label ?? key,
-        children: [] as [],
-      };
+    : emptyCallTree(key, beforeInfo?.label ?? key);
 
   if (!beforeInfo && afterInfo) {
     const diff = diffTrees(

--- a/src/languages/grammars.ts
+++ b/src/languages/grammars.ts
@@ -9,12 +9,34 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+/**
+ * Loaded tree-sitter grammar package surface.
+ * Named exports (`typescript`, `tsx`, …) are looked up by `resolveLanguage`.
+ */
 export type GrammarModule = {
-  language?: unknown;
+  language?: GrammarModule;
   typescript?: GrammarModule;
   tsx?: GrammarModule;
-  [key: string]: unknown;
+  [exportName: string]: GrammarModule | undefined;
 };
+
+/** Runtime grammar handle passed to `parser.setLanguage`. */
+export type GrammarLanguage = GrammarModule;
+
+type NativeBinding = GrammarModule & {
+  nodeTypeInfo?: object;
+};
+
+type NodeGypBuild = (root: string) => GrammarModule;
+
+type PackageJson = {
+  version?: string;
+};
+
+function errnoCode(err: Error): string | undefined {
+  // SAFETY: Node require/fs failures are ErrnoException with optional string code.
+  return (err as NodeJS.ErrnoException).code;
+}
 
 /** On-disk cache of npm-installed tree-sitter grammar packages. */
 export function grammarCacheDir(): string {
@@ -51,12 +73,11 @@ function ensureCachePackageJson(cacheDir: string): void {
 function loadNativeBinding(packageRoot: string): GrammarModule | null {
   try {
     const require = createRequire(join(packageRoot, "package.json"));
-    const gypBuild = require("node-gyp-build") as (
-      root: string,
-    ) => GrammarModule;
-    const binding = gypBuild(packageRoot);
+    // SAFETY: node-gyp-build's default export is (root) => native binding.
+    const gypBuild = require("node-gyp-build") as NodeGypBuild;
+    const binding: NativeBinding = gypBuild(packageRoot);
     try {
-      (binding as { nodeTypeInfo?: unknown }).nodeTypeInfo = require(
+      binding.nodeTypeInfo = require(
         join(packageRoot, "src", "node-types.json"),
       );
     } catch {
@@ -74,9 +95,10 @@ function requireGrammar(
   packageRoot: string,
 ): GrammarModule {
   try {
+    // SAFETY: grammar packages export a module compatible with GrammarModule.
     return require(npmPackage) as GrammarModule;
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException)?.code;
+    const code = err instanceof Error ? errnoCode(err) : undefined;
     const msg = err instanceof Error ? err.message : String(err);
     if (
       code === "ERR_REQUIRE_ASYNC_MODULE" ||
@@ -89,13 +111,17 @@ function requireGrammar(
   }
 }
 
-/** Packages that need a pinned install spec (latest breaks createRequire). */
-const INSTALL_SPEC: Record<string, string> = {
-  "tree-sitter-c-sharp": "tree-sitter-c-sharp@0.23.1",
-  // 0.4+ is ESM-with-TLA; 0.2.0 is CJS and loads via createRequire.
-  "@tree-sitter-grammars/tree-sitter-lua":
-    "@tree-sitter-grammars/tree-sitter-lua@0.2.0",
-};
+function installSpecFor(npmPackage: string): string {
+  switch (npmPackage) {
+    case "tree-sitter-c-sharp":
+      return "tree-sitter-c-sharp@0.23.1";
+    case "@tree-sitter-grammars/tree-sitter-lua":
+      // 0.4+ is ESM-with-TLA; 0.2.0 is CJS and loads via createRequire.
+      return "@tree-sitter-grammars/tree-sitter-lua@0.2.0";
+    default:
+      return npmPackage;
+  }
+}
 
 /**
  * Install an npm grammar package into the shared cache if missing, then require it.
@@ -106,9 +132,10 @@ export function loadGrammarPackage(npmPackage: string): GrammarModule {
   try {
     const localRequire = createRequire(import.meta.url);
     try {
+      // SAFETY: local dependency resolves to a tree-sitter grammar module.
       return localRequire(npmPackage) as GrammarModule;
     } catch (err) {
-      const code = (err as NodeJS.ErrnoException)?.code;
+      const code = err instanceof Error ? errnoCode(err) : undefined;
       const msg = err instanceof Error ? err.message : String(err);
       if (
         code === "ERR_REQUIRE_ASYNC_MODULE" ||
@@ -128,7 +155,6 @@ export function loadGrammarPackage(npmPackage: string): GrammarModule {
   const cacheDir = grammarCacheDir();
   if (!packageInstalled(cacheDir, npmPackage)) {
     ensureCachePackageJson(cacheDir);
-    const installSpec = INSTALL_SPEC[npmPackage] ?? npmPackage;
     execFileSync(
       "npm",
       [
@@ -139,7 +165,7 @@ export function loadGrammarPackage(npmPackage: string): GrammarModule {
         "--no-fund",
         "--no-audit",
         "--legacy-peer-deps",
-        installSpec,
+        installSpecFor(npmPackage),
       ],
       {
         stdio: ["ignore", "pipe", "pipe"],
@@ -157,7 +183,7 @@ export function loadGrammarPackage(npmPackage: string): GrammarModule {
 export function resolveLanguage(
   mod: GrammarModule,
   exportName?: string,
-): unknown {
+): GrammarLanguage {
   if (exportName) {
     const named = mod[exportName];
     if (named != null) return named;
@@ -173,10 +199,10 @@ export function readCachedPackageVersion(
   const pkgJson = join(cacheDir, "node_modules", npmPackage, "package.json");
   if (!existsSync(pkgJson)) return null;
   try {
-    const raw = JSON.parse(readFileSync(pkgJson, "utf8")) as {
-      version?: string;
-    };
-    return raw.version ?? null;
+    const raw: unknown = JSON.parse(readFileSync(pkgJson, "utf8"));
+    // SAFETY: npm package.json is JSON with an optional string version field.
+    const pkg = raw as PackageJson;
+    return pkg.version ?? null;
   } catch {
     return null;
   }

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -102,12 +102,15 @@ function collectStatements(
     const mark = `${key}:${node.startIndex}`;
     if (seen.has(mark)) return;
     seen.add(mark);
-    steps.push({
+    const step: CallStep = {
       type: "call",
       key,
       ...locFromNode(file, node),
-      ...(children && children.length > 0 ? { children } : {}),
-    });
+    };
+    if (children && children.length > 0) {
+      step.children = children;
+    }
+    steps.push(step);
   };
 
   // Lambda arguments of THIS call only — lambdas under a nested call belong to it.
@@ -255,7 +258,7 @@ function collectStatements(
     if (node.type === "call_expression") {
       // `f(args) { lambda }` parses as call_expression(call_expression(f, args), lambda):
       // unwrap to the innermost callee, keeping every suffix level's arguments.
-      const argSubtrees: SyntaxNode[] = [...namedChildren(node).slice(1)];
+      const argSubtrees: SyntaxNode[] = namedChildren(node).slice(1);
       let callee = node.namedChild(0);
       while (callee?.type === "call_expression") {
         argSubtrees.push(...namedChildren(callee).slice(1));

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -48,7 +48,7 @@ function getParamsLabel(params: SyntaxNode | null): string {
   return names.length === 0 ? "()" : `(${names.join(", ")})`;
 }
 
-function calleeKey(node: SyntaxNode, className: string | null): string | null {
+function calleeKey(node: SyntaxNode, _className: string | null): string | null {
   // Bare / qualified function call callee is usually `name` or `qualified_name`
   if (node.type === "name") return node.text;
   if (node.type === "qualified_name") {

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -370,17 +370,6 @@ function handleLambdaAssignment(
   );
 }
 
-function unwrapFunction(node: SyntaxNode): SyntaxNode | null {
-  if (node.type === "function_definition") return node;
-  if (node.type === "decorated_definition") {
-    return (
-      childByType(node, "function_definition") ??
-      childByType(node, "class_definition")
-    );
-  }
-  return null;
-}
-
 function hasPropertyDecorator(decorated: SyntaxNode): boolean {
   for (const child of namedChildren(decorated)) {
     if (child.type !== "decorator") continue;

--- a/src/reach.ts
+++ b/src/reach.ts
@@ -6,6 +6,7 @@ import {
 } from "./calltree.js";
 import type { FunctionIndex } from "./extract.js";
 import type { CallNode } from "./types.js";
+import { assignOptionalTreeFields } from "./types.js";
 
 function nodeMatchesTarget(
   nodeKey: string,
@@ -27,15 +28,12 @@ export function pathToTree(nodes: CallNode[]): CallNode {
     throw new Error("pathToTree requires at least one node");
   }
   const [head, ...rest] = nodes;
-  return {
+  const tree: CallNode = {
     key: head!.key,
     label: head!.label,
-    ...(head!.kind ? { kind: head!.kind } : {}),
-    ...(head!.file ? { file: head!.file } : {}),
-    ...(head!.line != null ? { line: head!.line } : {}),
-    ...(head!.endLine != null ? { endLine: head!.endLine } : {}),
     children: rest.length > 0 ? [pathToTree(rest)] : [],
   };
+  return assignOptionalTreeFields(tree, head!);
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -73,6 +73,7 @@ function renderAsciiTree(
     if (!showLocs) return "";
     const loc = pickLoc(node);
     if (!loc.file || loc.line == null) return "";
+    // SAFETY: file and line were just validated as present above.
     const text = `  ${formatSourceLoc(loc as SourceLoc)}`;
     return useColor ? pc.dim(text) : text;
   };

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,6 +35,7 @@ import type {
   Snapshot,
   TreeResult,
 } from "./types.js";
+import { assignOptionalTreeFields } from "./types.js";
 
 export type DiffRunOptions = {
   from?: string;
@@ -182,28 +183,22 @@ function resolveEntrypointInfos(
 }
 
 function serializeCallNode(node: CallNode): CallNode {
-  return {
+  const serialized: CallNode = {
     key: node.key,
     label: node.label,
-    ...(node.kind ? { kind: node.kind } : {}),
-    ...(node.file ? { file: node.file } : {}),
-    ...(node.line != null ? { line: node.line } : {}),
-    ...(node.endLine != null ? { endLine: node.endLine } : {}),
     children: node.children.map(serializeCallNode),
   };
+  return assignOptionalTreeFields(serialized, node);
 }
 
 function serializeDiffNode(node: DiffNode): DiffNode {
-  return {
+  const serialized: DiffNode = {
     key: node.key,
     label: node.label,
     status: node.status,
-    ...(node.kind ? { kind: node.kind } : {}),
-    ...(node.file ? { file: node.file } : {}),
-    ...(node.line != null ? { line: node.line } : {}),
-    ...(node.endLine != null ? { endLine: node.endLine } : {}),
     children: node.children.map(serializeDiffNode),
   };
+  return assignOptionalTreeFields(serialized, node);
 }
 
 /** Diff call stacks between two snapshots. Returns structured data + ASCII. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,44 @@ export interface Snapshot {
   ref: string;
 }
 
+export interface SnapshotPair {
+  from: Snapshot;
+  to: Snapshot;
+}
+
+export interface SnapshotPairWithPaths extends SnapshotPair {
+  paths: string[];
+}
+
+export interface SnapshotWithPaths {
+  snapshot: Snapshot;
+  paths: string[];
+}
+
+/** Copy optional location / kind fields onto a tree node without empty spreads. */
+export function assignOptionalTreeFields<
+  T extends {
+    kind?: CallNodeKind;
+    file?: string;
+    line?: number;
+    endLine?: number;
+  },
+>(
+  target: T,
+  source: {
+    kind?: CallNodeKind;
+    file?: string;
+    line?: number;
+    endLine?: number;
+  },
+): T {
+  if (source.kind) target.kind = source.kind;
+  if (source.file) target.file = source.file;
+  if (source.line != null) target.line = source.line;
+  if (source.endLine != null) target.endLine = source.endLine;
+  return target;
+}
+
 export type CliMode = "diff" | "tree" | "reach";
 
 export interface DiffTreeResult {

--- a/test/php.test.ts
+++ b/test/php.test.ts
@@ -79,14 +79,14 @@ test("php: refactors calls into a helper with if/else", () => {
     + │  ├─ create_coding_tools()
     + │  └─ new Services()
     + ├─ services.boot()
-      ├─ if !\$options
+      ├─ if !$options
          └─ SessionManager.create()
       └─ else
          └─ SessionManager.open(id)
   `));
 });
 
-test("php: \$this->method resolves to Class.method", () => {
+test("php: $this->method resolves to Class.method", () => {
   const host = workspace();
   const from = host.commit("before", {
     "/runner.php": src`
@@ -257,9 +257,9 @@ test("php: elseif chains", () => {
   expect(result.code).toBe(0);
   expect(result.stdout).toContain(diffOutdent(`
       handle(status)
-      ├─ if \$status == 1
+      ├─ if $status == 1
          └─ do_a()
-      ├─ elseif \$status == 2
+      ├─ elseif $status == 2
          ├─ do_b()
     +    └─ do_extra()
       └─ else


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies anti-slop rule findings to owned sources so `npm run lint` is clean.

**Depends on #45** (tooling-only). Base is `cursor/anti-slop-tooling-092d`; retarget to `main` after #45 merges if needed.

Includes named snapshot types, removal of conditional empty-object spreads, `SAFETY:` comments, grammar typing cleanups, `functionShape` → `functionFingerprint`, and related fixes.

## Verification

- `npm run lint` — clean
- `npm run build` — clean
- `npm test` — 279 passed

Supersedes the mixed #43.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3adc8cb8-d26a-4674-a091-38ec5497092d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3adc8cb8-d26a-4674-a091-38ec5497092d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

