### PR TITLE
fix(rust): extract functions from inline modules

### DIFF
--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -274,6 +274,33 @@ function handleImpl(
   }
 }
 
+function handleModule(
+  file: string,
+  node: SyntaxNode,
+  functions: FunctionInfo[],
+) {
+  const list = childByType(node, "declaration_list");
+  if (!list) return;
+
+  for (const item of namedChildren(list)) {
+    visit(file, item, functions);
+  }
+}
+
+function visit(file: string, node: SyntaxNode, functions: FunctionInfo[]) {
+  if (node.type === "function_item") {
+    handleFunctionItem(file, node, null, functions);
+    return;
+  }
+  if (node.type === "impl_item") {
+    handleImpl(file, node, functions);
+    return;
+  }
+  if (node.type === "mod_item") {
+    handleModule(file, node, functions);
+  }
+}
+
 function extractFromTree(
   file: string,
   _source: string,
@@ -281,11 +308,7 @@ function extractFromTree(
 ): FunctionInfo[] {
   const functions: FunctionInfo[] = [];
   for (const stmt of namedChildren(tree.rootNode)) {
-    if (stmt.type === "function_item") {
-      handleFunctionItem(file, stmt, null, functions);
-    } else if (stmt.type === "impl_item") {
-      handleImpl(file, stmt, functions);
-    }
+    visit(file, stmt, functions);
   }
   return functions;
 }

--- a/test/rust.test.ts
+++ b/test/rust.test.ts
@@ -386,3 +386,65 @@ test("rust: Type::method scoped calls and ignores bare field reads", () => {
     + └─ obj.other()
   `));
 });
+
+test("rust: recursively extracts functions from inline modules", () => {
+  const host = workspace();
+  const from = host.commit("before", {
+    "/inline.rs": src`
+       #[cfg(test)]
+       mod tests {
+           #[test]
+           fn creates_a_session() {
+               arrange();
+               create_session();
+           }
+
+           mod nested {
+               #[test]
+               fn rejects_a_session() {
+                   arrange();
+                   reject_session();
+               }
+           }
+       }
+    `,
+  });
+  const to = host.commit("after", {
+    "/inline.rs": src`
+       #[cfg(test)]
+       mod tests {
+           #[test]
+           fn creates_a_session() {
+               arrange();
+               create_session();
+               assert_session();
+           }
+
+           mod nested {
+               #[test]
+               fn rejects_a_session() {
+                   arrange();
+                   reject_session();
+                   assert_rejection();
+               }
+           }
+       }
+    `,
+  });
+
+  const result = host.run(`calldiff diff ${from} ${to}`);
+
+  expect(result.code).toBe(0);
+  expect(result.stdout).toContain(diffOutdent(`
+      creates_a_session()
+      ├─ arrange()
+      ├─ create_session()
+    + └─ assert_session()
+  `));
+  expect(result.stdout).toContain(diffOutdent(`
+      rejects_a_session()
+      ├─ arrange()
+      ├─ reject_session()
+    + └─ assert_rejection()
+  `));
+});


### PR DESCRIPTION
functions in inline modules in Rust like these:

```rust
#[cfg(test)]
mod tests {
  #[test]
  fn creates_a_session() {
      arrange();
      create_session();
  }
}
```

were silently ignored, which means `calldiff`s didnt include changes in test cases

this PR adds
- handling of inline modules (including nested modules)
- extracts the body of the `extractFromTree` root to a `visit` function (as done in C# and C++ impls) to make it possible to recurse into the module tree
- adds a test that verifies
    - `fn`s belonging to inline modules are recognized
    - `fn`s in nested inline modules are also recognised 
    
`#[cfg(test)]` gated modules are used in the test case, because that's probably the most common place for inline modules in rust

`npm run build` passes, `npm run lint` passes, `npm test` also passes

---

one issue I have with it is that its hard to tell which module / file the test comes from, but from what I've seen C++ and C# implementations also skip the module ancestry

I feel like this could be a separate PR which I could do if wanted, but might require additional thoughts about how to present that without cluttering the diff too much

if you want me to make a PR for this or discuss beforehand lmk :)